### PR TITLE
Remove redundant license references

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2022, STEPBible
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2022, STEPBible
+Copyright (c) 2012, STEPBible
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/step-assembly/src/main/assembly/log4j.properties
+++ b/step-assembly/src/main/assembly/log4j.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, MAIN_LOG,A1
 

--- a/step-build/pom.xml
+++ b/step-build/pom.xml
@@ -1,35 +1,3 @@
-<!--
-  Copyright (c) 2012, Directors of the Tyndale STEP Project
-  All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
-  modification, are permitted provided that the following conditions 
-  are met:
-  
-  Redistributions of source code must retain the above copyright 
-  notice, this list of conditions and the following disclaimer.
-  Redistributions in binary form must reproduce the above copyright 
-  notice, this list of conditions and the following disclaimer in 
-  the documentation and/or other materials provided with the 
-  distribution.
-  Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-  nor the names of its contributors may be used to endorse or promote 
-  products derived from this software without specific prior written 
-  permission.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-  THE POSSIBILITY OF SUCH DAMAGE.
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	

--- a/step-build/src/main/resources/eclipse/pmd.xml
+++ b/step-build/src/main/resources/eclipse/pmd.xml
@@ -1,36 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-  Copyright (c) 2012, Directors of the Tyndale STEP Project
-  All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
-  modification, are permitted provided that the following conditions 
-  are met:
-  
-  Redistributions of source code must retain the above copyright 
-  notice, this list of conditions and the following disclaimer.
-  Redistributions in binary form must reproduce the above copyright 
-  notice, this list of conditions and the following disclaimer in 
-  the documentation and/or other materials provided with the 
-  distribution.
-  Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-  nor the names of its contributors may be used to endorse or promote 
-  products derived from this software without specific prior written 
-  permission.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-  THE POSSIBILITY OF SUCH DAMAGE.
--->
 <pmd>
     <useProjectRuleSet>false</useProjectRuleSet>
     <ruleSetFile>.ruleset</ruleSetFile>

--- a/step-core/pom.xml
+++ b/step-core/pom.xml
@@ -1,23 +1,3 @@
-<!-- Copyright (c) 2012, Directors of the Tyndale STEP Project All rights 
-	reserved. Redistribution and use in source and binary forms, with or without 
-	modification, are permitted provided that the following conditions are met: 
-	Redistributions of source code must retain the above copyright notice, this 
-	list of conditions and the following disclaimer. Redistributions in binary 
-	form must reproduce the above copyright notice, this list of conditions and 
-	the following disclaimer in the documentation and/or other materials provided 
-	with the distribution. Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com) 
-	nor the names of its contributors may be used to endorse or promote products 
-	derived from this software without specific prior written permission. THIS 
-	SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-	DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-	ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
-	THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityConfiguration.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityConfiguration.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isNotBlank;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/common/GeoPrecision.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/common/GeoPrecision.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.common;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/common/PartialDate.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/common/PartialDate.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.common;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isEmpty;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/common/PrecisionType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/common/PrecisionType.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.common;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/HeadwordLineBasedLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/HeadwordLineBasedLoader.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.create;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isBlank;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/Loader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/Loader.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.create;
 
 import java.util.*;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/ModuleLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/ModuleLoader.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.create;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/aggregations/TimelineEventsAndDate.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/aggregations/TimelineEventsAndDate.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.entities.aggregations;
 
 import java.io.Serializable;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityManagerImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityManagerImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.entities.impl;
 
 import java.io.Closeable;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/AbstractClasspathBasedModuleLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/AbstractClasspathBasedModuleLoader.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.loaders;
 
 import static com.tyndalehouse.step.core.utils.IOUtils.closeQuietly;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/StreamingCsvModuleLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/StreamingCsvModuleLoader.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.loaders;
 
 import static com.tyndalehouse.step.core.utils.IOUtils.closeQuietly;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/AlternativeTranslationsProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/AlternativeTranslationsProcessor.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.processors;
 
 import javax.inject.Inject;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/AugmentedStrongProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/AugmentedStrongProcessor.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.processors;
 
 import com.tyndalehouse.step.core.data.EntityConfiguration;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/NaveProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/NaveProcessor.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.processors;
 
 import javax.inject.Inject;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/LocalisedException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/LocalisedException.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.exceptions;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/RequiresLoginException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/RequiresLoginException.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.exceptions;
 
 import static com.tyndalehouse.step.core.exceptions.UserExceptionType.LOGIN_REQUIRED;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/StepInternalException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/StepInternalException.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.exceptions;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/TranslatedException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/TranslatedException.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.exceptions;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/UserExceptionType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/UserExceptionType.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.exceptions;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/ValidationException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/ValidationException.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.exceptions;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/StepCoreModule.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/StepCoreModule.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.guice;
 
 import com.google.inject.TypeLiteral;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProvider.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.guice.providers;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.commaSeparate;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultVersionsProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultVersionsProvider.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.guice.providers;
 
 import java.util.ArrayList;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/BibleVersion.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/BibleVersion.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 import java.io.Serializable;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/ClientSession.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/ClientSession.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 import java.io.IOException;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/Definition.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/Definition.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/EnrichedLookupOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/EnrichedLookupOption.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/ExactForm.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/ExactForm.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 import java.io.Serializable;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/HasCsvValueName.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/HasCsvValueName.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/Language.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/Language.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/LookupOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/LookupOption.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 import com.tyndalehouse.step.core.exceptions.StepInternalException;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/Note.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/Note.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/OsisWrapper.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/OsisWrapper.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 import java.io.Serializable;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/TrimmedLookupOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/TrimmedLookupOption.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/VocabResponse.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/VocabResponse.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models;
 
 import java.util.HashMap;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionPhraseAlternative.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionPhraseAlternative.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.meanings;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionVersePhraseOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionVersePhraseOption.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.meanings;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionVerses.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionVerses.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.meanings;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionsData.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/meanings/VersionsData.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.meanings;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/BookAndBibleCount.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/BookAndBibleCount.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.search;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/LexicalSearchEntry.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/LexicalSearchEntry.java
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 package com.tyndalehouse.step.core.models.search;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/StrongCountsAndSubjects.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/StrongCountsAndSubjects.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.search;
 
 import com.tyndalehouse.step.core.models.LexiconSuggestion;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/CombinedPassageStats.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/CombinedPassageStats.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.stats;
 
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/PassageStat.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/PassageStat.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.models.stats;
 
 import com.tyndalehouse.step.core.models.KeyWrapper;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/AlternativeVersionsService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/AlternativeVersionsService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import com.tyndalehouse.step.core.models.meanings.VersionsData;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/BibleInformationService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/BibleInformationService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/GeographyService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/GeographyService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 //pt20201119 This code was never used so Patrick Tang commented it out on November 19, 2020.  Search for the "November 19, 2020" string to find all the related changes in the Java code.
 //pt20201119package com.tyndalehouse.step.core.service;
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/LanguageService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/LanguageService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import com.tyndalehouse.step.core.models.Language;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/ModuleService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/ModuleService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/MorphologyService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/MorphologyService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/NotesService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/NotesService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/SearchService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/SearchService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import com.tyndalehouse.step.core.models.AbstractComplexSearch;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/TimelineService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/TimelineService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import org.joda.time.LocalDateTime;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/VocabularyService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/VocabularyService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/VersionResolver.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/VersionResolver.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.helpers;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isBlank;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AlternativeTranslationsServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AlternativeTranslationsServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import static java.lang.String.format;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AnalysisServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AnalysisServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 import java.util.*;
 import java.util.regex.Pattern;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/BibleInformationServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/BibleInformationServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import com.tyndalehouse.step.core.data.DirectoryInstaller;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/GeographyServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/GeographyServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 //pt20201119 This code was never used so Patrick Tang commented it out on November 19, 2020.  Search for the "November 19, 2020" string to find all the related changes in the Java code.
 //pt20201119package com.tyndalehouse.step.core.service.impl;
 //pt20201119

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/IndividualSearch.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/IndividualSearch.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import com.tyndalehouse.step.core.exceptions.TranslatedException;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/InternationalRangeServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/InternationalRangeServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import com.tyndalehouse.step.core.models.BookName;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/LanguageServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/LanguageServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import static com.tyndalehouse.step.core.utils.language.ContemporaryLanguageUtils.capitaliseFirstLetter;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/ModuleServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/ModuleServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import static com.tyndalehouse.step.core.utils.JSwordUtils.getSortedSerialisableList;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/MorphologyServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/MorphologyServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.split;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchQuery.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchQuery.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchType.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/TimelineServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/TimelineServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import static com.tyndalehouse.step.core.utils.ConversionUtils.epochMinutesStringToLocalDateTime;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/VocabularyServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/VocabularyServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordMetadataService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordMetadataService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordModuleService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordModuleService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordPassageService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordPassageService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword;
 
 import java.util.List;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordVersificationService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordVersificationService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword;
 
 import com.tyndalehouse.step.core.models.KeyWrapper;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/helpers/JSwordStrongNumberHelper.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/helpers/JSwordStrongNumberHelper.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword.helpers;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordAnalysisServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordAnalysisServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword.impl;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.split;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword.impl;
 
 import com.tyndalehouse.step.core.exceptions.LocalisedException;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordSearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordSearchServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword.impl;
 
 import com.tyndalehouse.step.core.exceptions.LuceneSearchException;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordVersificationServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordVersificationServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword.impl;
 
 import javax.inject.Inject;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/SubjectSearchService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/SubjectSearchService.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.search;
 
 import com.tyndalehouse.step.core.models.search.SearchResult;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.search.impl;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectEntryServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectEntryServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.search.impl;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectSearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectSearchServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.search.impl;
 
 import com.google.inject.Singleton;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/AbstractStepGuiceModule.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/AbstractStepGuiceModule.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import java.io.IOException;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/IOUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/IOUtils.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import java.io.BufferedReader;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/JSwordUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/JSwordUtils.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import com.tyndalehouse.step.core.models.BibleVersion;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/SortingUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/SortingUtils.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in
- * the documentation and/or other materials provided with the
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)
- * nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import com.tyndalehouse.step.core.models.LexiconSuggestion;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringConversionUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringConversionUtils.java
@@ -1,36 +1,3 @@
-/*******************************************************************************
-
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import com.tyndalehouse.step.core.utils.language.GreekUtils;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringUtils.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import java.util.HashMap;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/ValidateUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/ValidateUtils.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isBlank;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/XslHelper.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/XslHelper.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import static com.tyndalehouse.step.core.utils.StringConversionUtils.getAnyKey;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/ContemporaryLanguageUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/ContemporaryLanguageUtils.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils.language;
 
 import java.util.Locale;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/InterlinearProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/InterlinearProvider.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/MultiInterlinearProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/MultiInterlinearProvider.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/XslConversionType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/XslConversionType.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl;
 
 /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/ColorCoderProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/ColorCoderProviderImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isBlank;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/CrossReferenceProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/CrossReferenceProviderImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import java.util.HashSet;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/DualKey.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/DualKey.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import static java.lang.String.format;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import java.util.ArrayList;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/MultiInterlinearProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/MultiInterlinearProviderImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import com.tyndalehouse.step.core.exceptions.StepInternalException;

--- a/step-core/src/main/resources/step.core.properties
+++ b/step-core/src/main/resources/step.core.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 #list of installers in the format: host,package,catalog
 installer.0=STEP Home directory,localhost-directory,#step-home#/offlineModules
 installer.1=CrossWire,www.crosswire.org,/ftpmirror/pub/sword/packages/rawzip,/ftpmirror/pub/sword/raw

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/common/PartialDateTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/common/PartialDateTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.common;
 
 import static org.junit.Assert.assertEquals;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/create/LoaderTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/create/LoaderTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.create;
 
 import static org.junit.Assert.assertEquals;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/MockJSwordPassageServiceImpl.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/MockJSwordPassageServiceImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.data.entities.impl;
 
 import java.util.List;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProviderTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProviderTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.guice.providers;
 
 import static org.junit.Assert.assertEquals;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/models/LookupOptionTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/models/LookupOptionTest.java
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 package com.tyndalehouse.step.core.models;
 
 import org.junit.Assert;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/prebuild/DownloadJSwordBiblesPreReq.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/prebuild/DownloadJSwordBiblesPreReq.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.prebuild;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isNotBlank;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/LanguageServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/LanguageServiceImplTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.impl;
 
 import static org.junit.Assert.assertTrue;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordAnalysisServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordAnalysisServiceImplTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword.impl;
 
 import com.tyndalehouse.step.core.models.stats.ScopeType;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImplTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.service.jsword.impl;
 
 import com.tyndalehouse.step.core.models.BookName;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringConversionUtilsTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringConversionUtilsTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import com.tyndalehouse.step.core.utils.language.transliteration.TransliterationOption;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringUtilsTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringUtilsTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import static org.junit.Assert.assertEquals;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/TestUtils.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/TestUtils.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.utils;
 
 import static org.mockito.Matchers.anyString;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/ColorCoderProviderImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/ColorCoderProviderImplTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImplTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImplTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.core.xsl.impl;
 
 import static org.junit.Assert.assertEquals;

--- a/step-core/src/test/resources/log4j.properties
+++ b/step-core/src/test/resources/log4j.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, A1
 

--- a/step-core/src/test/resources/step.core.properties
+++ b/step-core/src/test/resources/step.core.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Front controller properties
 frontcontroller.cache.enabled=false
 

--- a/step-packages/pom.xml
+++ b/step-packages/pom.xml
@@ -1,23 +1,3 @@
-<!-- Copyright (c) 2012, Directors of the Tyndale STEP Project All rights 
-	reserved. Redistribution and use in source and binary forms, with or without 
-	modification, are permitted provided that the following conditions are met: 
-	Redistributions of source code must retain the above copyright notice, this 
-	list of conditions and the following disclaimer. Redistributions in binary 
-	form must reproduce the above copyright notice, this list of conditions and 
-	the following disclaimer in the documentation and/or other materials provided 
-	with the distribution. Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com) 
-	nor the names of its contributors may be used to endorse or promote products 
-	derived from this software without specific prior written permission. THIS 
-	SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-	DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-	ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
-	THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>

--- a/step-server/pom.xml
+++ b/step-server/pom.xml
@@ -1,35 +1,3 @@
-<!--
-  Copyright (c) 2012, Directors of the Tyndale STEP Project
-  All rights reserved.
-  
-  Redistribution and use in source and binary forms, with or without 
-  modification, are permitted provided that the following conditions 
-  are met:
-  
-  Redistributions of source code must retain the above copyright 
-  notice, this list of conditions and the following disclaimer.
-  Redistributions in binary form must reproduce the above copyright 
-  notice, this list of conditions and the following disclaimer in 
-  the documentation and/or other materials provided with the 
-  distribution.
-  Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-  nor the names of its contributors may be used to endorse or promote 
-  products derived from this software without specific prior written 
-  permission.
-  
-  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-  COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-  IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-  THE POSSIBILITY OF SUCH DAMAGE.
--->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<parent>
 		<groupId>com.tyndalehouse.step</groupId>

--- a/step-server/src/main/resources/log4j.properties
+++ b/step-server/src/main/resources/log4j.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, MAIN_LOG,A1
 

--- a/step-tools/pom.xml
+++ b/step-tools/pom.xml
@@ -1,23 +1,3 @@
-<!-- Copyright (c) 2012, Directors of the Tyndale STEP Project All rights 
-	reserved. Redistribution and use in source and binary forms, with or without 
-	modification, are permitted provided that the following conditions are met: 
-	Redistributions of source code must retain the above copyright notice, this 
-	list of conditions and the following disclaimer. Redistributions in binary 
-	form must reproduce the above copyright notice, this list of conditions and 
-	the following disclaimer in the documentation and/or other materials provided 
-	with the distribution. Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com) 
-	nor the names of its contributors may be used to endorse or promote products 
-	derived from this software without specific prior written permission. THIS 
-	SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-	DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-	ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
-	THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/MultiMap.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/MultiMap.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.tools;
 
 import java.util.Collection;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/MultiMapIndexer.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/MultiMapIndexer.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.tools;
 
 /**

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter.java
@@ -1,37 +1,4 @@
 // Chris Bradshaw
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 package com.tyndalehouse.step.tools.analysis;
 
 import com.tyndalehouse.step.core.utils.StringConversionUtils;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter2.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter2.java
@@ -1,37 +1,4 @@
 // Chris Bradshaw
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 package com.tyndalehouse.step.tools.analysis;
 
 import com.tyndalehouse.step.core.utils.StringConversionUtils;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputToTaggingFormat.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputToTaggingFormat.java
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 package com.tyndalehouse.step.tools.analysis;
 
 import org.apache.commons.io.FileUtils;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ModuleToStrong.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ModuleToStrong.java
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 package com.tyndalehouse.step.tools.analysis;
 
 import org.apache.commons.io.FileUtils;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/EsvXmlEnhancer.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/EsvXmlEnhancer.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.tools.esv;
 
 import com.tyndalehouse.step.tools.MultiMap;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/international/AllLanguages.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/international/AllLanguages.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.tools.international;
 
 import java.util.Locale;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/versions/ParseVersionFile.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/versions/ParseVersionFile.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.tools.versions;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isNotBlank;

--- a/step-tools/src/main/resources/log4j.properties
+++ b/step-tools/src/main/resources/log4j.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=TRACE, A1
 

--- a/step-tools/src/main/resources/step.core.properties
+++ b/step-tools/src/main/resources/step.core.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Front controller properties
 frontcontroller.cache.enabled=false
 

--- a/step-tools/src/test/java/com/tyndalehouse/step/tools/esv/EsvXmlEnhancerTest.java
+++ b/step-tools/src/test/java/com/tyndalehouse/step/tools/esv/EsvXmlEnhancerTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.tools.esv;
 
 import static org.junit.Assert.assertEquals;

--- a/step-tools/src/test/java/com/tyndalehouse/step/tools/esv/StrongNumberFilterTest.java
+++ b/step-tools/src/test/java/com/tyndalehouse/step/tools/esv/StrongNumberFilterTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.tools.esv;
 
 import static org.mockito.Mockito.mock;

--- a/step-web-test/pom.xml
+++ b/step-web-test/pom.xml
@@ -1,23 +1,3 @@
-<!-- Copyright (c) 2012, Directors of the Tyndale STEP Project All rights 
-	reserved. Redistribution and use in source and binary forms, with or without 
-	modification, are permitted provided that the following conditions are met: 
-	Redistributions of source code must retain the above copyright notice, this 
-	list of conditions and the following disclaimer. Redistributions in binary 
-	form must reproduce the above copyright notice, this list of conditions and 
-	the following disclaimer in the documentation and/or other materials provided 
-	with the distribution. Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com) 
-	nor the names of its contributors may be used to endorse or promote products 
-	derived from this software without specific prior written permission. THIS 
-	SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
-	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-	DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-	ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF 
-	THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>

--- a/step-web-test/src/test/java/com/tyndalehouse/step/e2e/framework/WebDriverUtils.java
+++ b/step-web-test/src/test/java/com/tyndalehouse/step/e2e/framework/WebDriverUtils.java
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 package com.tyndalehouse.step.e2e.framework;
 
 import org.openqa.selenium.Keys;

--- a/step-web-test/src/test/resources/log4j.properties
+++ b/step-web-test/src/test/resources/log4j.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=TRACE, A1
 

--- a/step-web/pom.xml
+++ b/step-web/pom.xml
@@ -1,23 +1,3 @@
-<!-- Copyright (c) 2012, Directors of the Tyndale STEP Project All rights
-	reserved. Redistribution and use in source and binary forms, with or without
-	modification, are permitted provided that the following conditions are met:
-	Redistributions of source code must retain the above copyright notice, this
-	list of conditions and the following disclaimer. Redistributions in binary
-	form must reproduce the above copyright notice, this list of conditions and
-	the following disclaimer in the documentation and/or other materials provided
-	with the distribution. Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)
-	nor the names of its contributors may be used to endorse or promote products
-	derived from this software without specific prior written permission. THIS
-	SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-	ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-	WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
-	IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-	DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-	(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-	LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-	ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-	(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-	THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/ExternalPoweredByFilter.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/ExternalPoweredByFilter.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.guice;
 
 import java.io.IOException;

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/HashBangFragmentFilter.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/HashBangFragmentFilter.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.guice;
 
 import com.tyndalehouse.step.core.utils.StringUtils;

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/StepServletConfig.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/StepServletConfig.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.guice;
 
 import com.google.inject.Guice;

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/StepWebModule.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/StepWebModule.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.guice;
 
 import com.google.inject.servlet.ServletScopes;

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/providers/ClientSessionProvider.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/providers/ClientSessionProvider.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.guice.providers;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isNotBlank;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/AbstractSearchStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/AbstractSearchStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import java.util.Locale;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/AdvancedSearchStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/AdvancedSearchStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import java.util.ResourceBundle;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/PrefaceStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/PrefaceStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import javax.servlet.http.HttpServletRequest;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/SimpleSearchStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/SimpleSearchStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import java.util.ResourceBundle;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import com.google.inject.Injector;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionsStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionsStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import java.util.ArrayList;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/WebStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/WebStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isEmpty;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/WordSearchStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/WordSearchStepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.jsp;
 
 import java.util.ResourceBundle;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/ClientOperation.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/ClientOperation.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models;
 
 /**

--- a/step-web/src/main/java/com/tyndalehouse/step/models/TimelineTranslator.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/TimelineTranslator.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models;
 
 import org.joda.time.LocalDateTime;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/UiDefaults.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/UiDefaults.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models;
 
 import com.google.inject.Inject;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/WebSessionImpl.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/WebSessionImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models;
 
 import java.io.IOException;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/info/Info.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/info/Info.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models.info;
 
 import java.util.List;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/info/MorphInfo.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/info/MorphInfo.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 01, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models.info;
 
 import java.io.Serializable;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/info/VocabInfo.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/info/VocabInfo.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 01, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models.info;
 
 import com.tyndalehouse.step.core.data.EntityDoc;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/DigestableTimeline.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/DigestableTimeline.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models.timeline;
 
 /**

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileEvent.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileEvent.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models.timeline.simile;
 
 import com.tyndalehouse.step.models.timeline.DigestableTimeline;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineImpl.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models.timeline.simile;
 
 import java.util.List;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineTranslatorImpl.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineTranslatorImpl.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.models.timeline.simile;
 
 import static com.tyndalehouse.step.core.utils.ConversionUtils.epochMinutesStringToLocalDateTime;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/AlternativeTranslationsController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/AlternativeTranslationsController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import javax.inject.Inject;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/AnalysisController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/AnalysisController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import javax.inject.Inject;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/BibleController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/BibleController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import static com.tyndalehouse.step.core.exceptions.UserExceptionType.APP_MISSING_FIELD;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/GeographyController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/GeographyController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 //pt20201119 This code was never used so Patrick Tang commented it out on November 19, 2020.  Search for the "November 19, 2020" string to find all the related changes in the Java code.
 //pt20201119package com.tyndalehouse.step.rest.controllers;
 

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/ImageController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/ImageController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import java.io.File;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/InternationalJsonController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/InternationalJsonController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import com.tyndalehouse.step.core.exceptions.StepInternalException;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/ModuleController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/ModuleController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import com.google.inject.Inject;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SetupController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SetupController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import static com.tyndalehouse.step.core.exceptions.UserExceptionType.CONTROLLER_INITIALISATION_ERROR;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SiteMapController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SiteMapController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import java.io.IOException;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/TimelineController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/TimelineController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import com.google.inject.Inject;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/UserController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/UserController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import static com.tyndalehouse.step.core.exceptions.UserExceptionType.CONTROLLER_INITIALISATION_ERROR;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/external/V1Controller.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/external/V1Controller.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers.external;
 
 import java.util.List;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientErrorResolver.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientErrorResolver.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 import java.util.HashMap;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientHandledIssue.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientHandledIssue.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 import java.io.Serializable;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ControllerCacheKey.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ControllerCacheKey.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 /**

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/FrontController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/FrontController.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 import com.google.inject.Inject;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/JsonResourceBundle.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/JsonResourceBundle.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 import java.util.*;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/StepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/StepRequest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 import java.io.UnsupportedEncodingException;

--- a/step-web/src/main/resources/log4j.properties
+++ b/step-web/src/main/resources/log4j.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 # Set root logger level to DEBUG and its only appender to A1.
 log4j.rootLogger=INFO, A1
 

--- a/step-web/src/main/resources/step.web.properties
+++ b/step-web/src/main/resources/step.web.properties
@@ -1,35 +1,3 @@
-#-------------------------------------------------------------------------------
-# Copyright (c) 2012, Directors of the Tyndale STEP Project
-# All rights reserved.
-# 
-# Redistribution and use in source and binary forms, with or without 
-# modification, are permitted provided that the following conditions 
-# are met:
-# 
-# Redistributions of source code must retain the above copyright 
-# notice, this list of conditions and the following disclaimer.
-# Redistributions in binary form must reproduce the above copyright 
-# notice, this list of conditions and the following disclaimer in 
-# the documentation and/or other materials provided with the 
-# distribution.
-# Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
-# nor the names of its contributors may be used to endorse or promote 
-# products derived from this software without specific prior written 
-# permission.
-# 
-# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
-# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
-# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
-# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
-# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
-# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
-# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
-# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
-# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
-# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
-# THE POSSIBILITY OF SUCH DAMAGE.
-#-------------------------------------------------------------------------------
 
 # This file sets up the defaults and other properties for the web frontend
 app.ui.defaults.1.version=ESV

--- a/step-web/src/main/webapp/js/backbone/models/model_history.js
+++ b/step-web/src/main/webapp/js/backbone/models/model_history.js
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 var HistoryModel = Backbone.Model.extend({
     defaults: function () {
         return {

--- a/step-web/src/main/webapp/js/backbone/views/view_feedback.js
+++ b/step-web/src/main/webapp/js/backbone/views/view_feedback.js
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 var FeedbackView = Backbone.View.extend({
     el: function () {
         return $("body")

--- a/step-web/src/main/webapp/js/backbone/views/view_quick_lexicon.js
+++ b/step-web/src/main/webapp/js/backbone/views/view_quick_lexicon.js
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 var QuickLexicon = Backbone.View.extend({
     templateHeader: '<div id="quickLexicon"><div>' +
         '<div>' +

--- a/step-web/src/main/webapp/js/backbone/views/view_restore.js
+++ b/step-web/src/main/webapp/js/backbone/views/view_restore.js
@@ -1,36 +1,3 @@
-/**************************************************************************************************
- * Copyright (c) 2013, Directors of the Tyndale STEP Project                                      *
- * All rights reserved.                                                                           *
- *                                                                                                *
- * Redistribution and use in source and binary forms, with or without                             *
- * modification, are permitted provided that the following conditions                             *
- * are met:                                                                                       *
- *                                                                                                *
- * Redistributions of source code must retain the above copyright                                 *
- * notice, this list of conditions and the following disclaimer.                                  *
- * Redistributions in binary form must reproduce the above copyright                              *
- * notice, this list of conditions and the following disclaimer in                                *
- * the documentation and/or other materials provided with the                                     *
- * distribution.                                                                                  *
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)                        *
- * nor the names of its contributors may be used to endorse or promote                            *
- * products derived from this software without specific prior written                             *
- * permission.                                                                                    *
- *                                                                                                *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS                            *
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT                              *
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS                              *
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE                                 *
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,                           *
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,                           *
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;                               *
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER                               *
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT                             *
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING                                 *
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF                                 *
- * THE POSSIBILITY OF SUCH DAMAGE.                                                                *
- **************************************************************************************************/
-
 var RestorePassageView = Backbone.View.extend({
         template: '<div class="modal" id="restorePassages" tabindex="-1" role="dialog" aria-labelledby="restorePassagesLabel" ' +
             'aria-hidden="true">' +

--- a/step-web/src/main/webapp/js/defaults/step.defaults.js
+++ b/step-web/src/main/webapp/js/defaults/step.defaults.js
@@ -1,32 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project All rights
- * reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer. Redistributions in binary
- * form must reproduce the above copyright notice, this list of conditions and
- * the following disclaimer in the documentation and/or other materials provided
- * with the distribution. Neither the name of the Tyndale House, Cambridge
- * (www.TyndaleHouse.com) nor the names of its contributors may be used to
- * endorse or promote products derived from this software without specific prior
- * written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
-
 ////////////////////////////////////////
 // LANGUAGE
 ////////////////////////////////////////

--- a/step-web/src/main/webapp/js/geography.js
+++ b/step-web/src/main/webapp/js/geography.js
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 /**
  * Code for showing and interacting with the timeline
  */

--- a/step-web/src/main/webapp/js/passage/step.passage.js
+++ b/step-web/src/main/webapp/js/passage/step.passage.js
@@ -1,32 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project All rights
- * reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer. Redistributions in binary
- * form must reproduce the above copyright notice, this list of conditions and
- * the following disclaimer in the documentation and/or other materials provided
- * with the distribution. Neither the name of the Tyndale House, Cambridge
- * (www.TyndaleHouse.com) nor the names of its contributors may be used to
- * endorse or promote products derived from this software without specific prior
- * written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
-
 var CONTINUOUS_SCROLLING_VERSE_GAP = 50;
 
 step.passage = {

--- a/step-web/src/main/webapp/js/setup/step.config.js
+++ b/step-web/src/main/webapp/js/setup/step.config.js
@@ -1,32 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project All rights
- * reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer. Redistributions in binary
- * form must reproduce the above copyright notice, this list of conditions and
- * the following disclaimer in the documentation and/or other materials provided
- * with the distribution. Neither the name of the Tyndale House, Cambridge
- * (www.TyndaleHouse.com) nor the names of its contributors may be used to
- * endorse or promote products derived from this software without specific prior
- * written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
-
 // add case insensitive contains
 $.expr[":"].icontains = $.expr.createPseudo(function(arg) {
     return function( elem ) {

--- a/step-web/src/main/webapp/js/setup/step.firstTime.js
+++ b/step-web/src/main/webapp/js/setup/step.firstTime.js
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in
- * the documentation and/or other materials provided with the
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)
- * nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 
 if (!step) {
     step = {};

--- a/step-web/src/main/webapp/js/state/step.state.js
+++ b/step-web/src/main/webapp/js/state/step.state.js
@@ -1,31 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project All rights
- * reserved.
- * 
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- * 
- * Redistributions of source code must retain the above copyright notice, this
- * list of conditions and the following disclaimer. Redistributions in binary
- * form must reproduce the above copyright notice, this list of conditions and
- * the following disclaimer in the documentation and/or other materials provided
- * with the distribution. Neither the name of the Tyndale House, Cambridge
- * (www.TyndaleHouse.com) nor the names of its contributors may be used to
- * endorse or promote products derived from this software without specific prior
- * written permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
- * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
- * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
- * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
- * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
- * POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 step.state = {
     responseLanguage : undefined,
     language : function(numParts) {

--- a/step-web/src/main/webapp/js/step.util.js
+++ b/step-web/src/main/webapp/js/step.util.js
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions
- * are met:
- *
- * Redistributions of source code must retain the above copyright
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright
- * notice, this list of conditions and the following disclaimer in
- * the documentation and/or other materials provided with the
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)
- * nor the names of its contributors may be used to endorse or promote
- * products derived from this software without specific prior written
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 (function ($) {
     //some extensions (perhaps should go in another file)
     String.prototype.startsWith = function (nonEscapedString) {

--- a/step-web/src/main/webapp/js/timeline.js
+++ b/step-web/src/main/webapp/js/timeline.js
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 
 var HEBREW_MONTH_NAMES = [ 
     [__s.timeline_month_january, "Tevet" ], 

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/controllers/BibleControllerTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/controllers/BibleControllerTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.controllers;
 
 import static org.junit.Assert.fail;

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/framework/FrontControllerTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/framework/FrontControllerTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- *
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 import static org.junit.Assert.assertArrayEquals;

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/framework/StepRequestTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/framework/StepRequestTest.java
@@ -1,35 +1,3 @@
-/*******************************************************************************
- * Copyright (c) 2012, Directors of the Tyndale STEP Project
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
- * are met:
- * 
- * Redistributions of source code must retain the above copyright 
- * notice, this list of conditions and the following disclaimer.
- * Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in 
- * the documentation and/or other materials provided with the 
- * distribution.
- * Neither the name of the Tyndale House, Cambridge (www.TyndaleHouse.com)  
- * nor the names of its contributors may be used to endorse or promote 
- * products derived from this software without specific prior written 
- * permission.
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS 
- * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE 
- * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, 
- * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, 
- * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
- * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
- * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF 
- * THE POSSIBILITY OF SUCH DAMAGE.
- ******************************************************************************/
 package com.tyndalehouse.step.rest.framework;
 
 import static org.junit.Assert.assertEquals;


### PR DESCRIPTION
### Why

Previously, this repo has attached a license to every individual file. This leads to a lot of unnecessary content in the file and extra mental overhead. It also has no legal advantage over having just one license file at the root level.