### PR TITLE
Remove unnecessary author comments

### DIFF
--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/AllResultsCollector.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/AllResultsCollector.java
@@ -10,9 +10,6 @@ import org.apache.lucene.search.Scorer;
 
 /**
  * Simply accepts all results into a list
- * 
- * @author chrisburrell
- * 
  */
 public class AllResultsCollector extends Collector {
     private final List<Integer> docIds = new ArrayList<Integer>(32);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/AnalyzedPrefixSearchQueryParser.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/AnalyzedPrefixSearchQueryParser.java
@@ -14,10 +14,6 @@ import org.apache.lucene.util.Version;
 
 import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
-/**
- * 
- * @author chrisburrell
- */
 public class AnalyzedPrefixSearchQueryParser extends MultiFieldQueryParser {
     /**
      * delegates to super constructor

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/DirectoryInstaller.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/DirectoryInstaller.java
@@ -20,9 +20,6 @@ import org.crosswire.jsword.book.install.sword.AbstractSwordInstaller;
 
 /**
  * Installs packages from a directory
- * 
- * @author chrisburrell
- * 
  */
 public class DirectoryInstaller extends AbstractSwordInstaller {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/DirectoryListingInstaller.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/DirectoryListingInstaller.java
@@ -28,8 +28,6 @@ import java.util.zip.ZipInputStream;
 
 /**
  * Bases the list of books based on the directory listing of a particular folder, as opposed to a zip file of some kind.
- *
- * @author chrisburrell
  */
 public class DirectoryListingInstaller extends DirectoryInstaller {
     public static String DIRECTORY_LISTING_INSTALLER = "directory-listing-installer";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityConfiguration.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityConfiguration.java
@@ -27,9 +27,6 @@ import com.tyndalehouse.step.core.utils.IOUtils;
 
 /**
  * A configuration of the entity, include the list of fields, etc.
- * 
- * @author chrisburrell
- * 
  */
 public class EntityConfiguration {
     private static final String UNABLE_TO_PARSE_CONFIGURATION_FILE = "Unable to parse configuration file";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityDoc.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityDoc.java
@@ -10,11 +10,6 @@ import org.apache.lucene.document.Fieldable;
 import org.codehaus.jackson.annotate.JsonAnyGetter;
 import org.codehaus.jackson.annotate.JsonIgnore;
 
-/**
- * 
- * @author chrisburrell
- * 
- */
 public class EntityDoc implements Serializable {
     private static final long serialVersionUID = -8509022678959062751L;
     private final Document doc;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityIndexReader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityIndexReader.java
@@ -18,8 +18,6 @@ import org.apache.lucene.search.TopFieldCollector;
 
 /**
  * Interface to read an index
- *
- * @author chrisburrell
  */
 public interface EntityIndexReader extends Closeable {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityManager.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/EntityManager.java
@@ -4,9 +4,6 @@ import com.tyndalehouse.step.core.data.entities.impl.EntityIndexWriterImpl;
 
 /**
  * Interface for entity managers
- * 
- * @author chrisburrell
- * 
  */
 public interface EntityManager {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/FieldConfig.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/FieldConfig.java
@@ -14,9 +14,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Records how a field is stored in Lucene
- * 
- * @author chrisburrell
- * 
  */
 public class FieldConfig {
     private static final String MINUTE = "minute";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/StepHttpSwordInstaller.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/StepHttpSwordInstaller.java
@@ -20,8 +20,6 @@ import java.util.zip.ZipInputStream;
 
 /**
  * Bases the list of books based on the directory listing of a particular folder, as opposed to a zip file of some kind.
- *
- * @author chrisburrell
  */
 public class StepHttpSwordInstaller extends HttpSwordInstaller {
     private String installerName;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/AncientLanguageAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/AncientLanguageAnalyzer.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.data.filters.NormalizerFilter;
 
 /**
  * Analyzer to remove the accents and other marks that make it difficult for a user to search
- * 
- * @author chrisburrell
- * 
  */
 public class AncientLanguageAnalyzer extends Analyzer {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/BetaAccentedAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/BetaAccentedAnalyzer.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.data.filters.BetaTransliterationCleaningFilter
 
 /**
  * An analyzer for transliterations
- * 
- * @author chrisburrell
- * 
  */
 public class BetaAccentedAnalyzer extends Analyzer {
     @Override

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/CommaDelimitedAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/CommaDelimitedAnalyzer.java
@@ -9,9 +9,6 @@ import com.tyndalehouse.step.core.data.tokenizers.CommaDelimitedTokenizer;
 
 /**
  * Just uses whitespaces to separate tokens
- * 
- * @author chrisburrell
- * 
  */
 public class CommaDelimitedAnalyzer extends Analyzer {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/DefinitionAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/DefinitionAnalyzer.java
@@ -7,9 +7,6 @@ import org.apache.lucene.util.Version;
 
 /**
  * Class to analyze various definition fields
- * 
- * @author chrisburrell
- * 
  */
 public class DefinitionAnalyzer extends PerFieldAnalyzerWrapper {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/NaveAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/NaveAnalyzer.java
@@ -11,9 +11,6 @@ import javax.inject.Inject;
 
 /**
  * analyzes Nave modules
- * 
- * @author chrisburrell
- * 
  */
 public class NaveAnalyzer extends PerFieldAnalyzerWrapper {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/ReferenceAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/ReferenceAnalyzer.java
@@ -7,9 +7,6 @@ import org.apache.lucene.analysis.WhitespaceTokenizer;
 
 import java.io.Reader;
 
-/**
- * @author chrisburrell
- */
 public class ReferenceAnalyzer extends Analyzer {
     @Override
     public TokenStream tokenStream(final String fieldName, final Reader reader) {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/SpecificFormAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/SpecificFormAnalyzer.java
@@ -7,9 +7,6 @@ import org.apache.lucene.util.Version;
 
 /**
  * Analyzer for specific forms
- * 
- * @author chrisburrell
- * 
  */
 public class SpecificFormAnalyzer extends PerFieldAnalyzerWrapper {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/TimelineAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/TimelineAnalyzer.java
@@ -8,9 +8,6 @@ import org.apache.lucene.util.Version;
 
 /**
  * Geography analyzer
- * 
- * @author chrisburrell
- * 
  */
 public class TimelineAnalyzer extends PerFieldAnalyzerWrapper {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/TransliterationAnalyzer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/analyzers/TransliterationAnalyzer.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.data.filters.TransliterationCleaningFilter;
 
 /**
  * An analyzer for transliterations
- * 
- * @author chrisburrell
- * 
  */
 public class TransliterationAnalyzer extends Analyzer {
     @Override

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/common/PrecisionType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/common/PrecisionType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.data.common;
 
 /**
  * Precision type indicating how trustworthy a date is when passed through the system
- * 
- * @author chrisburrell
- * 
  */
 public enum PrecisionType {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/common/TermsAndMaxCount.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/common/TermsAndMaxCount.java
@@ -5,7 +5,6 @@ import java.util.Set;
 /**
  * Holds a set of matching terms, with the total potential count of all terms
  * @param <T> the type of term that is held here.
- * @author chrisburrell
  */
 public class TermsAndMaxCount<T> {
     private Set<T> terms;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/HeadwordLineBasedLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/HeadwordLineBasedLoader.java
@@ -15,9 +15,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Loads an Easton Dictionary
- * 
- * @author chrisburrell
- * 
  */
 public class HeadwordLineBasedLoader extends AbstractClasspathBasedModuleLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(HeadwordLineBasedLoader.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/Loader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/Loader.java
@@ -35,8 +35,6 @@ import com.tyndalehouse.step.core.service.StrongAugmentationService;
  * the Bible.
  * <p/>
  * Note, this object is not thread-safe.
- *
- * @author chrisburrell
  */
 public class Loader {
     private static final Logger LOGGER = LoggerFactory.getLogger(Loader.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/PostProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/PostProcessor.java
@@ -6,9 +6,6 @@ import com.tyndalehouse.step.core.data.EntityConfiguration;
 
 /**
  * Post-processes a document before it is added to the index
- * 
- * @author chrisburrell
- * 
  */
 public interface PostProcessor {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/SpecificFormsLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/SpecificFormsLoader.java
@@ -14,9 +14,6 @@ import com.tyndalehouse.step.core.data.loaders.AbstractClasspathBasedModuleLoade
 
 /**
  * Loads up all lexical forms
- * 
- * @author chrisburrell
- * 
  */
 public class SpecificFormsLoader extends AbstractClasspathBasedModuleLoader {
     private static final Logger LOGGER = LoggerFactory.getLogger(HeadwordLineBasedLoader.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/aggregations/TimelineEventsAndDate.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/aggregations/TimelineEventsAndDate.java
@@ -8,9 +8,6 @@ import com.tyndalehouse.step.core.data.EntityDoc;
 
 /**
  * A simple wrapper around a timeline set of events and a central date
- * 
- * @author chrisburrell
- * 
  */
 public class TimelineEventsAndDate implements Serializable {
     private static final long serialVersionUID = -7079914843690188557L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityIndexReaderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityIndexReaderImpl.java
@@ -38,8 +38,6 @@ import com.tyndalehouse.step.core.utils.IOUtils;
 
 /**
  * Reads an entity
- *
- * @author chrisburrell
  */
 public class EntityIndexReaderImpl implements EntityIndexReader {
     private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(EntityIndexReaderImpl.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityIndexWriterImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityIndexWriterImpl.java
@@ -27,9 +27,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Reads a file and creates the equivalent Lucene index for it. This class is not thread safe.
- * 
- * @author chrisburrell
- * 
  */
 public class EntityIndexWriterImpl {
     private static final Logger LOGGER = LoggerFactory.getLogger(EntityIndexWriterImpl.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityManagerImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/entities/impl/EntityManagerImpl.java
@@ -13,10 +13,6 @@ import com.tyndalehouse.step.core.data.EntityConfiguration;
 import com.tyndalehouse.step.core.data.EntityIndexReader;
 import com.tyndalehouse.step.core.data.EntityManager;
 
-/**
- * @author chrisburrell
- * 
- */
 @Singleton
 public class EntityManagerImpl implements Closeable, EntityManager {
     private final Map<String, EntityConfiguration> configs = new HashMap<String, EntityConfiguration>();

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/filters/BetaTransliterationCleaningFilter.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/filters/BetaTransliterationCleaningFilter.java
@@ -8,9 +8,6 @@ import org.apache.lucene.analysis.tokenattributes.TermAttribute;
 
 /**
  * Cleans up transliterations by removing any extra character
- * 
- * @author chrisburrell
- * 
  */
 public class BetaTransliterationCleaningFilter extends TokenFilter {
     private final TermAttribute termAtt;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/filters/NormalizerFilter.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/filters/NormalizerFilter.java
@@ -10,9 +10,6 @@ import org.apache.lucene.analysis.tokenattributes.TermAttribute;
 
 /**
  * Normalizes the String and removes any accents
- * 
- * @author chrisburrell
- * 
  */
 public class NormalizerFilter extends TokenFilter {
     private final TermAttribute termAtt;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/filters/TransliterationCleaningFilter.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/filters/TransliterationCleaningFilter.java
@@ -8,9 +8,6 @@ import org.apache.lucene.analysis.tokenattributes.TermAttribute;
 
 /**
  * Cleans up transliterations by removing any extra character
- * 
- * @author chrisburrell
- * 
  */
 public class TransliterationCleaningFilter extends TokenFilter {
     private final TermAttribute termAtt;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/AbstractClasspathBasedModuleLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/AbstractClasspathBasedModuleLoader.java
@@ -15,8 +15,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Loads modules straight from a CSV file to a database form
- *
- * @author chrisburrell
  */
 public abstract class AbstractClasspathBasedModuleLoader implements ModuleLoader {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractClasspathBasedModuleLoader.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/GeoStreamingCsvModuleLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/GeoStreamingCsvModuleLoader.java
@@ -12,9 +12,6 @@
 
 /**
  * Used for Geography
- * 
- * @author chrisburrell
- * 
  */
 //pt20201119public class GeoStreamingCsvModuleLoader extends StreamingCsvModuleLoader {
 //pt20201119    private static final String PRECISION_EXACT = "exact";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/StreamingCsvModuleLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/StreamingCsvModuleLoader.java
@@ -17,8 +17,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Loads modules straight from a CSV file to a database form
- *
- * @author chrisburrell
  */
 public class StreamingCsvModuleLoader extends AbstractClasspathBasedModuleLoader {
     private static final Logger LOG = LoggerFactory.getLogger(StreamingCsvModuleLoader.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/TimelineStreamingCsvModuleLoader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/loaders/TimelineStreamingCsvModuleLoader.java
@@ -10,9 +10,6 @@
 
 /**
  * Loads all historical data
- * 
- * @author chrisburrell
- * 
  */
 //pt20201119public class TimelineStreamingCsvModuleLoader extends StreamingCsvModuleLoader {
 //pt20201119    private final JSwordPassageService jsword;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/AugmentedStrongProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/AugmentedStrongProcessor.java
@@ -13,8 +13,6 @@ import java.util.regex.Pattern;
 
 /**
  * Adds generated fields to the entity document - affects both "definition" and "specificForm"
- *
- * @author chrisburrell
  */
 public class AugmentedStrongProcessor implements PostProcessor {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/MorphologyProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/MorphologyProcessor.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.data.create.PostProcessor;
 
 /**
  * Cleanses strings in descriptions
- * 
- * @author chrisburrell
- * 
  */
 @SuppressWarnings("PMD")
 public class MorphologyProcessor implements PostProcessor {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/NaveProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/NaveProcessor.java
@@ -15,8 +15,6 @@ import java.util.regex.Pattern;
 
 /**
  * Adds generated fields to the entity document - affects both "definition" and "specificForm"
- *
- * @author chrisburrell
  */
 public class NaveProcessor implements PostProcessor {
     private static final Logger LOGGER = LoggerFactory.getLogger(NaveProcessor.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/TransliteratorProcessor.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/processors/TransliteratorProcessor.java
@@ -12,9 +12,6 @@ import org.apache.lucene.document.Field;
 
 /**
  * Adds generated fields to the entity document - affects both "definition" and "specificForm"
- * 
- * @author chrisburrell
- * 
  */
 public class TransliteratorProcessor implements PostProcessor {
     private static final String STEP_SIMPLIFIED_TRANSLITERATION = "simplifiedStepTransliteration";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/tokenizers/CommaDelimitedTokenizer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/tokenizers/CommaDelimitedTokenizer.java
@@ -4,7 +4,6 @@ import java.io.Reader;
 
 import org.apache.lucene.analysis.WhitespaceTokenizer;
 
-
 public class CommaDelimitedTokenizer extends WhitespaceTokenizer {
     /**
      * delegates to super constructor

--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/tokenizers/CommaDelimitedTokenizer.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/tokenizers/CommaDelimitedTokenizer.java
@@ -4,10 +4,7 @@ import java.io.Reader;
 
 import org.apache.lucene.analysis.WhitespaceTokenizer;
 
-/**
- * @author chrisburrell
- * 
- */
+
 public class CommaDelimitedTokenizer extends WhitespaceTokenizer {
     /**
      * delegates to super constructor

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/LocalisedException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/LocalisedException.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.core.exceptions;
 /**
  * The default exception to be thrown throughout the application. It is of type {@link RuntimeException} so
  * that it does not require explicit catching
- * 
- * @author chrisburrell
- * 
  */
 public class LocalisedException extends StepInternalException {
     private static final long serialVersionUID = -1083871793637352613L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/LuceneSearchException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/LuceneSearchException.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.core.exceptions;
 
-/**
- * @author chrisburrell
- */
 public class LuceneSearchException extends StepInternalException {
     /**
      * @see {@link com.tyndalehouse.step.core.exceptions.StepInternalException }

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/RequiresLoginException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/RequiresLoginException.java
@@ -4,9 +4,6 @@ import static com.tyndalehouse.step.core.exceptions.UserExceptionType.LOGIN_REQU
 
 /**
  * The default exception to be thrown when a feature is unavailable because authentication is required.
- * 
- * @author chrisburrell
- * 
  */
 public class RequiresLoginException extends ValidationException {
     private static final long serialVersionUID = 2447731047608723592L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/StepInternalException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/StepInternalException.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.core.exceptions;
 /**
  * The default exception to be thrown throughout the application. It is of type {@link RuntimeException} so
  * that it does not require explicit catching
- * 
- * @author chrisburrell
- * 
  */
 public class StepInternalException extends RuntimeException {
     private static final long serialVersionUID = -5636677138385910988L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/TranslatedException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/TranslatedException.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.core.exceptions;
 /**
  * The default exception to be thrown throughout the application. It is of type {@link RuntimeException} so
  * that it does not require explicit catching
- * 
- * @author chrisburrell
- * 
  */
 public class TranslatedException extends StepInternalException {
     private static final long serialVersionUID = -1083871793637352613L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/UserExceptionType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/UserExceptionType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.exceptions;
 
 /**
  * Contains a list of errors and their corresponding error messages, a step towards localisation
- * 
- * @author chrisburrell
- * 
  */
 public enum UserExceptionType {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/ValidationException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/exceptions/ValidationException.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.core.exceptions;
 /**
  * The default exception to be thrown throughout the application when a validation exception has occurred. It
  * is of type {@link StepInternal} so that it does not require explicit catching
- * 
- * @author chrisburrell
- * 
  */
 public class ValidationException extends StepInternalException {
     private static final long serialVersionUID = -5636677138385910988L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/StepCoreModule.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/StepCoreModule.java
@@ -38,8 +38,6 @@ import java.util.Properties;
 
 /**
  * The module configuration that configures the application via guice
- *
- * @author chrisburrell
  */
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class StepCoreModule extends AbstractStepGuiceModule {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProvider.java
@@ -30,9 +30,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Provides a set of installers for installing Bibles, modules, etc e.g. from Crosswire
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class DefaultInstallersProvider implements Provider<List<Installer>> {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultVersionsProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/DefaultVersionsProvider.java
@@ -10,9 +10,6 @@ import com.google.inject.Provides;
 
 /**
  * Provides a list of default versions that should be installed for the application
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class DefaultVersionsProvider implements Provider<List<String>> {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/OfflineInstallersProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/providers/OfflineInstallersProvider.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.data.DirectoryInstaller;
 
 /**
  * Provides only offline installers
- * 
- * @author chrisburrell
- * 
  */
 public class OfflineInstallersProvider extends DefaultInstallersProvider {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/AbstractComplexSearch.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/AbstractComplexSearch.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 /**
  * Parent class sharing to share some common properties between lookups for passages and searches
- * @author chrisburrell
  */
 public abstract class AbstractComplexSearch {
     private String title;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/AvailableFeatures.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/AvailableFeatures.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 /**
  * Features that are available to a particular version/displayMode with explanations of why others aren't
- * 
- * @author chrisburrell
- * 
  */
 public class AvailableFeatures {
     private List<LookupOption> options;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/BibleInstaller.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/BibleInstaller.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models;
 
 import java.io.Serializable;
 
-/**
- * @author chrisburrell
- */
 public class BibleInstaller implements Serializable {
     private static final long serialVersionUID = -1;
     private int index;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/BookName.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/BookName.java
@@ -8,8 +8,6 @@ import java.io.Serializable;
 
 /**
  * Gives info on a book name (short and long names)
- *
- * @author chrisburrell
  */
 public class BookName implements Serializable, PopularSuggestion {
     private static final long serialVersionUID = 2406197083965523605L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/ClientSession.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/ClientSession.java
@@ -6,8 +6,6 @@ import java.util.Locale;
 
 /**
  * At the moment, the "Client Session" object just wraps around an id.
- *
- * @author chrisburrell
  */
 public interface ClientSession {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/Definition.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/Definition.java
@@ -3,7 +3,6 @@ package com.tyndalehouse.step.core.models;
 /**
  * Represents a definition, has a key and a value
  * 
- * @author chrisburrell
  */
 public class Definition {
     private final String key;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/EnhancedTimelineEvent.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/EnhancedTimelineEvent.java
@@ -8,9 +8,6 @@ import com.tyndalehouse.step.core.data.EntityDoc;
 
 /**
  * Adds some key non-persisted fields to the event
- * 
- * @author chrisburrell
- * 
  */
 public class EnhancedTimelineEvent implements Serializable {
     private static final long serialVersionUID = -1338450485439161040L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/EnrichedLookupOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/EnrichedLookupOption.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models;
 
 /**
  * Outlines a list of options available in lookup
- * 
- * @author chrisburrell 
- * 
  */
 public class EnrichedLookupOption {
     private final String displayName;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/HasCsvValueName.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/HasCsvValueName.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models;
 
 /**
  * Provides an (English) display name
- * 
- * @author chrisburrell
- * 
  */
 public interface HasCsvValueName {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/InterlinearMode.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/InterlinearMode.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.core.models;
 /**
  * Indicates the output required by the user, interleaving, column view or interlinear. Interleaving and
  * column views also support difference checking
- * 
- * @author chrisburrell
- * 
  */
 public enum InterlinearMode {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/KeyWrapper.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/KeyWrapper.java
@@ -5,9 +5,6 @@ import org.crosswire.jsword.passage.Key;
 
 /**
  * Wraps around an OSIS Key
- * 
- * @author chrisburrell
- * 
  */
 public class KeyWrapper {
     private String osisKeyId;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/LexiconSuggestion.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/LexiconSuggestion.java
@@ -4,9 +4,6 @@ import com.tyndalehouse.step.core.models.search.PopularSuggestion;
 
 import java.io.Serializable;
 
-/**
- * @author chrisburrell
- */
 public class LexiconSuggestion implements Serializable, PopularSuggestion {
     private static final long serialVersionUID = 2330563074130087347L;
     private String strongNumber;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/LookupOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/LookupOption.java
@@ -13,8 +13,6 @@ import java.util.Map;
  * Outlines a list of options available in lookup
  * <p/>
  * Used letters at last update: ACDEHLMNPRTVU_
- *
- * @author chrisburrell
  */
 public enum LookupOption {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/OsisWrapper.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/OsisWrapper.java
@@ -13,9 +13,6 @@ import com.tyndalehouse.step.core.utils.HeadingsUtil;
 
 /**
  * A simple wrapper around a string for returning as a JSON-mapped object
- * 
- * @author chrisburrell
- * 
  */
 public class OsisWrapper extends AbstractComplexSearch implements Serializable {
     private static final long serialVersionUID = -5651330317995494895L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/SearchToken.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/SearchToken.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models;
 
 import java.io.Serializable;
 
-/**
- * @author chrisburrell
- */
 public class SearchToken implements Serializable {
     public static final String VERSION = "version";
     public static final String REFERENCE = "reference";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/ShortLexiconDefinition.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/ShortLexiconDefinition.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models;
 
 /**
  * A very short lexicon definition
- * 
- * @author chrisburrell
- * 
  */
 public class ShortLexiconDefinition {
     private String code;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/SingleSuggestionsSummary.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/SingleSuggestionsSummary.java
@@ -5,9 +5,6 @@ import com.tyndalehouse.step.core.models.search.SuggestionType;
 
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public class SingleSuggestionsSummary {
     private String searchType;
     private List<? extends PopularSuggestion> popularSuggestions;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/SuggestionsSummary.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/SuggestionsSummary.java
@@ -2,10 +2,6 @@ package com.tyndalehouse.step.core.models;
 
 import java.util.List;
 
-/**
- * 
- * @author chrisburrell
- */
 public class SuggestionsSummary {
     private List<SingleSuggestionsSummary> suggestionsSummaries;
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/TrimmedLookupOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/TrimmedLookupOption.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models;
 
 /**
  * An option that was removed because it was incompatible with how a passage was being looked up
- * 
- * @author chrisburrell
- * 
  */
 public class TrimmedLookupOption {
     private String explanation;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/AutoSuggestion.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/AutoSuggestion.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models.search;
 
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public class AutoSuggestion {
     private String itemType;
     private Object suggestion;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/ExpandableSubjectHeadingEntry.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/ExpandableSubjectHeadingEntry.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models.search;
 
 /**
  * An expandable header
- * 
- * @author chrisburrell
- * 
  */
 public class ExpandableSubjectHeadingEntry implements SearchEntry {
     private static final long serialVersionUID = -7042352819214882916L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/KeyedVerseContent.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/KeyedVerseContent.java
@@ -4,9 +4,6 @@ import java.io.Serializable;
 
 /**
  * Keyed content, e.g. by version
- * 
- * @author chrisburrell
- * 
  */
 public class KeyedVerseContent implements Serializable {
     private static final long serialVersionUID = -1522196279945422299L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/LexicalSearchEntry.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/LexicalSearchEntry.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.core.models.search;
 
-/**
- * @author chrisburrell
- */
 public class LexicalSearchEntry implements SearchEntry {
     private String stepGloss;
     private String stepTransliteration;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/PopularSuggestion.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/PopularSuggestion.java
@@ -1,7 +1,4 @@
 package com.tyndalehouse.step.core.models.search;
 
-/**
- * @author chrisburrell
- */
 public interface PopularSuggestion {
 }

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SearchEntry.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SearchEntry.java
@@ -4,9 +4,6 @@ import java.io.Serializable;
 
 /**
  * An interface indicating that the object contains 1 search result entry
- * 
- * @author chrisburrell
- * 
  */
 public interface SearchEntry extends Serializable {
 }

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SearchResult.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SearchResult.java
@@ -9,10 +9,6 @@ import com.tyndalehouse.step.core.models.AbstractComplexSearch;
 import com.tyndalehouse.step.core.models.LexiconSuggestion;
 import com.tyndalehouse.step.core.service.impl.SearchType;
 
-/**
- * 
- * @author chrisburrell
- */
 public class SearchResult extends AbstractComplexSearch implements Serializable {
     private static final long serialVersionUID = 5408141957094432935L;
     private String query;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SubjectSuggestion.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SubjectSuggestion.java
@@ -5,9 +5,6 @@ import com.tyndalehouse.step.core.service.impl.SearchType;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public class SubjectSuggestion implements PopularSuggestion {
     private String value;
     private List<SearchType> searchTypes;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SuggestionType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SuggestionType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models.search;
 
 /**
  * A type of lexical suggestion
- * 
- * @author chrisburrell
- * 
  */
 public enum SuggestionType {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SyntaxSuggestion.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/SyntaxSuggestion.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.core.models.search;
 
-/**
- * @author chrisburrell
- */
 public class SyntaxSuggestion extends TextSuggestion implements PopularSuggestion {
     private String value;
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/TextSuggestion.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/TextSuggestion.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.core.models.search;
 
-/**
- * @author chrisburrell
- */
 public class TextSuggestion implements PopularSuggestion {
     private String text;
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/TimelineEventSearchEntry.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/TimelineEventSearchEntry.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.models.search;
 
 /**
  * Carries timeline events
- * 
- * @author chrisburrell
- * 
  */
 public class TimelineEventSearchEntry implements SearchEntry {
     private static final long serialVersionUID = -1271009882198165554L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/search/VerseSearchEntry.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/search/VerseSearchEntry.java
@@ -2,8 +2,6 @@ package com.tyndalehouse.step.core.models.search;
 
 /**
  * Represents a result that was a match to the original query
- *
- * @author chrisburrell
  */
 public class VerseSearchEntry extends LexicalSearchEntry {
     private static final long serialVersionUID = 5620645768146160462L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/PassageStat.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/PassageStat.java
@@ -7,9 +7,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
-/**
- * @author chrisburrell
- */
 public class PassageStat {
     private Map<String, Integer[]> stats = new HashMap<String, Integer[]>(128);
     private KeyWrapper reference;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/ScopeType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/ScopeType.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.core.models.stats;
 
-/**
- * @author chrisburrell
- */
 public enum ScopeType {
     /** original words/strongs */
     CHAPTER,

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/StatType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/stats/StatType.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.core.models.stats;
 
-/**
- * @author chrisburrell
- */
 public enum StatType {
     /** original words/strongs */
     WORD,

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/AnalysisService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/AnalysisService.java
@@ -6,8 +6,6 @@ import com.tyndalehouse.step.core.models.stats.CombinedPassageStats;
 
 /**
  * Defines an interface for obtaining various stats on a passage.
- *
- * @author chrisburrell
  */
 public interface AnalysisService {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/AppManagerService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/AppManagerService.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.service;
 
 import java.io.File;
 
-/**
- * @author chrisburrell
- */
 public interface AppManagerService {
     /**
      * The app.version property

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/BibleInformationService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/BibleInformationService.java
@@ -10,9 +10,6 @@ import com.tyndalehouse.step.core.models.stats.PassageStat;
 /**
  * Interface to the service that gives information about the books of the bible, the different types of bible,
  * etc. This service will mainly use JSword but may also rely on other data sources to display text.
- * 
- * @author chrisburrell
- * 
  */
 public interface BibleInformationService {
     public static final char UNAVAILABLE_TO_UI = '_';

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/InternationalRangeService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/InternationalRangeService.java
@@ -4,9 +4,6 @@ import com.tyndalehouse.step.core.models.BookName;
 
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public interface InternationalRangeService {
     /**
      * For a particular user locale, provided by the client session, returns all

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/JSwordRelatedVersesService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/JSwordRelatedVersesService.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.service;
 
 import org.crosswire.jsword.passage.Key;
 
-/**
- * @author chrisburrell
- */
 public interface JSwordRelatedVersesService {
     /**
      * Finds all related verses from a particular key

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/LexiconDefinitionService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/LexiconDefinitionService.java
@@ -7,7 +7,6 @@ import java.util.Set;
 
 /**
  * Defines the contract for getting lexicon definitions out of Lucene
- * @author chrisburrell
  */
 public interface LexiconDefinitionService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/ModuleService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/ModuleService.java
@@ -9,8 +9,6 @@ import com.tyndalehouse.step.core.models.BibleVersion;
 /**
  * Interface to the service that gives information about the books of the bible, the different types of bible,
  * etc. This service will mainly use JSword but may also rely on other data sources to display text.
- *
- * @author chrisburrell
  */
 public interface ModuleService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/MorphologyService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/MorphologyService.java
@@ -6,9 +6,6 @@ import com.tyndalehouse.step.core.data.EntityDoc;
 
 /**
  * The service providing morphology information
- * 
- * @author chrisburrell
- * 
  */
 public interface MorphologyService {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/PassageOptionsValidationService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/PassageOptionsValidationService.java
@@ -9,9 +9,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-/**
- * @author chrisburrell
- */
 public interface PassageOptionsValidationService {
     /**
      * Translates the options provided over the HTTP interface to something palatable by the service layer

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/SearchService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/SearchService.java
@@ -10,8 +10,6 @@ import java.util.List;
 
 /**
  * Runs various searches across the underlying database
- *
- * @author chrisburrell
  */
 public interface SearchService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/SingleTypeSuggestionService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/SingleTypeSuggestionService.java
@@ -15,7 +15,6 @@ import java.util.List;
 /**
  * @param <T> the type of intermediate result returned. Generally, either a String or an EntityDoc
  * @param <S> the type of collector to collect the results with the remaining count
- * @author chrisburrell
  */
 public interface SingleTypeSuggestionService<T, S> {
     T[] getExactTerms(SuggestionContext context, int max, final boolean popularSort);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/SuggestionService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/SuggestionService.java
@@ -9,8 +9,6 @@ import com.tyndalehouse.step.core.service.impl.SearchType;
  * The suggestion service will provide two sets of results.
  * 1- we may want the top 3 results from many different sources
  * 2- we may want the first 50 results from one source
- *
- * @author chrisburrell
  */
 public interface SuggestionService {
     int MAX_RESULTS_NON_GROUPED = 50;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/SupportRequestService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/SupportRequestService.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.core.service;
 
-/**
- * @author chrisburrell
- */
 public interface SupportRequestService {
     /**
      * @param summary     summary of issue

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/SwingService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/SwingService.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.service;
 
 import com.tyndalehouse.step.core.models.BibleInstaller;
 
-/**
- * @author chrisburrell
- */
 public interface SwingService {
     /**
      * Adds a directory installer

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/TimelineService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/TimelineService.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.models.EnhancedTimelineEvent;
  * etc.
  * 
  * The timeline data is currently loaded from a CSV file and stored in the database
- * 
- * @author chrisburrell
- * 
  */
 public interface TimelineService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/UserService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/UserService.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.service;
 
 /**
  * Checks the identify of a user
- * 
- * @author chrisburrell
- * 
  */
 public interface UserService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/VocabularyService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/VocabularyService.java
@@ -5,9 +5,6 @@ import com.tyndalehouse.step.core.models.VocabResponse;
 
 /**
  * The service providing morphology information
- * 
- * @author chrisburrell
- * 
  */
 public interface VocabularyService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/GlossComparator.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/GlossComparator.java
@@ -8,9 +8,6 @@ import org.apache.lucene.analysis.StopAnalyzer;
 
 /**
  * Compares a definition by gloss
- * 
- * @author chrisburrell
- * 
  */
 public class GlossComparator implements Comparator<EntityDoc> {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/OriginalWordUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/OriginalWordUtils.java
@@ -14,9 +14,6 @@ import org.apache.lucene.search.TermQuery;
 
 /**
  * Static helper methods used by various services
- * 
- * @author chrisburrell
- * 
  */
 public final class OriginalWordUtils {
     /** strong number field */

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/SuggestionCollector.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/SuggestionCollector.java
@@ -8,9 +8,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public class SuggestionCollector extends Collector {
     private final List<Integer> docIds = new ArrayList<Integer>(32);
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/SuggestionContext.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/helpers/SuggestionContext.java
@@ -3,8 +3,6 @@ package com.tyndalehouse.step.core.service.helpers;
 /**
  * Holds various information about the context into which a user is typing.
  * For example, a selected version could influence the results of the key/book/ref retrieval
- *
- * @author chrisburrell
  */
 public class SuggestionContext {
     private String masterBook;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AbortQueryException.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AbortQueryException.java
@@ -4,9 +4,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Indicates that a query should be aborted and no results returned...
- * 
- * @author chrisburrell
- * 
  */
 public class AbortQueryException extends StepInternalException {
     private static final long serialVersionUID = 8482324997663864434L;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AnalysisServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AnalysisServiceImpl.java
@@ -29,8 +29,6 @@ import com.tyndalehouse.step.core.service.BibleInformationService;
 /**
  * A service able to retrieve various kinds of statistics, delegates to {@link JSwordAnalysisServiceImpl} for
  * some operations.
- *
- * @author chrisburrell
  */
 public class AnalysisServiceImpl implements AnalysisService {
     public static final String OSIS_CHAPTER_STARTS_WITH = ".* ";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AppManagerImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/AppManagerImpl.java
@@ -19,8 +19,6 @@ import java.util.Properties;
 
 /**
  * Allows querying of app-specific properties, such as the installation properties
- *
- * @author chrisburrell
  */
 @Singleton
 public class AppManagerImpl implements AppManagerService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/IndividualSearch.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/IndividualSearch.java
@@ -17,8 +17,6 @@ import static com.tyndalehouse.step.core.utils.StringUtils.split;
 
 /**
  * Represents an individual search
- *
- * @author chrisburrell
  */
 public class IndividualSearch {
     public static final Pattern MAIN_RANGE = Pattern.compile("(\\+\\[([^\\]]+)\\])");

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/JSwordRelatedVersesServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/JSwordRelatedVersesServiceImpl.java
@@ -37,9 +37,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public class JSwordRelatedVersesServiceImpl implements JSwordRelatedVersesService {
     private static final Logger LOG = LoggerFactory.getLogger(JSwordRelatedVersesServiceImpl.class);
     private static final int SIGNIFICANT_CUT_OFF = 200;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/LexiconDataProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/LexiconDataProvider.java
@@ -5,7 +5,6 @@ import com.tyndalehouse.step.core.data.EntityDoc;
 /**
  * Provides an abstraction around this to get one piece of data out
  * @param <K> the type that will be extracted
- * @author chrisburrell
  * 
  */
 public interface LexiconDataProvider {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/LexiconDefinitionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/LexiconDefinitionServiceImpl.java
@@ -13,9 +13,6 @@ import com.tyndalehouse.step.core.models.LexiconSuggestion;
 import com.tyndalehouse.step.core.models.search.SuggestionType;
 import com.tyndalehouse.step.core.service.LexiconDefinitionService;
 
-/**
- * @author chrisburrell
- */
 public class LexiconDefinitionServiceImpl implements LexiconDefinitionService {
     private final EntityIndexReader definitions;
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/ModuleServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/ModuleServiceImpl.java
@@ -21,9 +21,6 @@ import com.tyndalehouse.step.core.service.jsword.JSwordModuleService;
 
 /**
  * Looks up module information, for example lexicon definitions for particular references
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class ModuleServiceImpl implements ModuleService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/MorphologyServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/MorphologyServiceImpl.java
@@ -18,9 +18,6 @@ import com.tyndalehouse.step.core.service.MorphologyService;
 
 /**
  * Provides quick access to the morphology from a code found in the xsl transformation
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class MorphologyServiceImpl implements MorphologyService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/PassageOptionsValidationServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/PassageOptionsValidationServiceImpl.java
@@ -34,9 +34,6 @@ import static com.tyndalehouse.step.core.models.LookupOption.TRANSLITERATION;
 import static com.tyndalehouse.step.core.models.LookupOption.VERSE_NUMBERS;
 import static com.tyndalehouse.step.core.utils.StringUtils.isBlank;
 
-/**
- * @author chrisburrell
- */
 @Singleton
 public class PassageOptionsValidationServiceImpl implements PassageOptionsValidationService {
     private final Provider<ClientSession> clientSessionProvider;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchQuery.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchQuery.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 /**
  * Search query object. Defines all parameters required to execute a search
- *
- * @author chrisburrell
  */
 public class SearchQuery {
     private static final String JOINING_SEARCH = "=>";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchType.java
@@ -3,7 +3,6 @@ package com.tyndalehouse.step.core.service.impl;
 /**
  * Indicates the type of search that is executed.
  * 
- * @author chrisburrell
  */
 public enum SearchType {
     PASSAGE(""),

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SupportRequestServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SupportRequestServiceImpl.java
@@ -48,8 +48,6 @@ import static com.tyndalehouse.step.core.utils.StringUtils.getNonNullString;
 
 /**
  * Accesses JIRA to raise a support request.
- *
- * @author chrisburrell
  */
 @Singleton
 public class SupportRequestServiceImpl implements SupportRequestService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SwingServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SwingServiceImpl.java
@@ -16,8 +16,6 @@ import java.util.ResourceBundle;
 
 /**
  * This class wraps around the Swing interface!
- *
- * @author chrisburrell
  */
 public class SwingServiceImpl implements SwingService {
     private static final Logger LOGGER = LoggerFactory.getLogger(SwingServiceImpl.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/TimelineServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/TimelineServiceImpl.java
@@ -32,7 +32,6 @@ import com.tyndalehouse.step.core.utils.StringUtils;
 /**
  * The implementation of the timeline service, based on JDBC and ORM Lite to access the database.
  * 
- * @author chrisburrell
  */
 @Singleton
 public class TimelineServiceImpl implements TimelineService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/UserServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/UserServiceImpl.java
@@ -32,7 +32,6 @@ import com.tyndalehouse.step.core.utils.IOUtils;
  * A user service implementation, that checks whether a user is allowed in. Then given a number of parameters,
  * either registers the user automatically, or denies access...
  * 
- * @author chrisburrell
  */
 @Singleton
 public class UserServiceImpl implements UserService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/VocabularyServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/VocabularyServiceImpl.java
@@ -27,8 +27,6 @@ import static com.tyndalehouse.step.core.utils.ValidateUtils.notBlank;
 
 /**
  * defines all vocab related queries
- *
- * @author chrisburrell
  */
 @Singleton
 public class VocabularyServiceImpl implements VocabularyService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AbstractAncientSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AbstractAncientSuggestionServiceImpl.java
@@ -25,9 +25,6 @@ import java.util.List;
 
 import static com.tyndalehouse.step.core.service.helpers.OriginalWordUtils.convertToSuggestion;
 
-/**
- * @author chrisburrell
- */
 public abstract class AbstractAncientSuggestionServiceImpl implements SingleTypeSuggestionService<EntityDoc, TopFieldCollector> {
     private final EntityIndexReader reader;
     private final Sort popularSort;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AbstractIgnoreMergedListSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AbstractIgnoreMergedListSuggestionServiceImpl.java
@@ -11,7 +11,6 @@ import java.util.List;
 /**
  * A abstract implementation that assumes the first list (exact matches) have been merged
  * already, so we will only ever return the second list.
- * @author chrisburrell
  */
 public abstract class AbstractIgnoreMergedListSuggestionServiceImpl<T extends  PopularSuggestion> implements SingleTypeSuggestionService<T, TermsAndMaxCount<T>> {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AncientLanguageSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AncientLanguageSuggestionServiceImpl.java
@@ -18,9 +18,6 @@ import java.util.regex.Pattern;
 
 import static com.tyndalehouse.step.core.utils.language.HebrewUtils.isHebrewText;
 
-/**
- * @author chrisburrell
- */
 public abstract class AncientLanguageSuggestionServiceImpl extends AbstractAncientSuggestionServiceImpl {
     private static final Pattern PART_STRONG = Pattern.compile("(g|h)\\d\\d+");
     private static final SortField TRANSLIT_SORT_FIELD = new SortField("stepTransliteration", SortField.STRING_VAL);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AncientMeaningSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/AncientMeaningSuggestionServiceImpl.java
@@ -7,7 +7,6 @@ import org.apache.lucene.search.SortField;
 
 /**
  * Sets up the popular and gloss sorts
- * @author chrisburrell
  */
 public abstract class AncientMeaningSuggestionServiceImpl extends FieldBasedMeaningSuggestionServiceImpl {
     public static final SortField GLOSS_SORT_FIELD = new SortField("stepGloss", SortField.STRING_VAL);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/FieldBasedMeaningSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/FieldBasedMeaningSuggestionServiceImpl.java
@@ -10,9 +10,6 @@ import org.apache.lucene.search.Sort;
 
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public abstract class FieldBasedMeaningSuggestionServiceImpl extends AbstractAncientSuggestionServiceImpl {
     public FieldBasedMeaningSuggestionServiceImpl(final EntityIndexReader reader, final Filter filter,
                                                   final Sort sort, final Sort popularSort) {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/GreekAncientLanguageServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/GreekAncientLanguageServiceImpl.java
@@ -4,9 +4,6 @@ import com.tyndalehouse.step.core.data.EntityManager;
 
 import javax.inject.Inject;
 
-/**
- * @author chrisburrell
- */
 public class GreekAncientLanguageServiceImpl extends AncientLanguageSuggestionServiceImpl {
     @Inject
     public GreekAncientLanguageServiceImpl(final EntityManager entityManager) {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/GreekAncientMeaningServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/GreekAncientMeaningServiceImpl.java
@@ -7,7 +7,6 @@ import javax.inject.Inject;
 /**
  * Provides terms for Greek unicode or transliterations
  * 
- * @author chrisburrell
  */
 public class GreekAncientMeaningServiceImpl extends AncientMeaningSuggestionServiceImpl {
     @Inject

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/HebrewAncientLanguageServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/HebrewAncientLanguageServiceImpl.java
@@ -4,9 +4,6 @@ import com.tyndalehouse.step.core.data.EntityManager;
 
 import javax.inject.Inject;
 
-/**
- * @author chrisburrell
- */
 public class HebrewAncientLanguageServiceImpl extends AncientLanguageSuggestionServiceImpl {
     @Inject
     public HebrewAncientLanguageServiceImpl(final EntityManager entityManager) {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/HebrewAncientMeaningServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/HebrewAncientMeaningServiceImpl.java
@@ -7,7 +7,6 @@ import javax.inject.Inject;
 /**
  * Provides terms for Greek and Hebrew glosses
  * 
- * @author chrisburrell
  */
 public class HebrewAncientMeaningServiceImpl extends AncientMeaningSuggestionServiceImpl {
     @Inject

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/MeaningSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/MeaningSuggestionServiceImpl.java
@@ -15,9 +15,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 
-/**
- * @author chrisburrell
- */
 public class MeaningSuggestionServiceImpl implements SingleTypeSuggestionService<String, TermsAndMaxCount<String>> {
     private static final String[] ANCIENT_MEANING_FIELDS = new String[]{"stepGloss", "translations"};
     private final EntityIndexReader definitions;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/ReferenceSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/ReferenceSuggestionServiceImpl.java
@@ -28,8 +28,6 @@ import java.util.*;
  * The getNonExactTerms method will attempt to match against BibleBook names first, and then will use
  * parsed key if available and suggest a few chapters that
  * would make sense.
- *
- * @author chrisburrell
  */
 public class ReferenceSuggestionServiceImpl extends AbstractIgnoreMergedListSuggestionServiceImpl<BookName> {
     private static final String BOOK_CHAPTER_FORMAT = "%s %d";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/SubjectSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/SubjectSuggestionServiceImpl.java
@@ -18,9 +18,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.TreeMap;
 
-/**
- * @author chrisburrell
- */
 public class SubjectSuggestionServiceImpl extends AbstractIgnoreMergedListSuggestionServiceImpl<SubjectSuggestion> {
     private final EntityIndexReader naves;
     private final JSwordSearchService jSwordSearchService;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/SuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/SuggestionServiceImpl.java
@@ -25,8 +25,6 @@ import java.util.Map;
 
 /**
  * Suggestion service, helping the auto suggestion search dropdown.
- *
- * @author chrisburrell
  */
 public class SuggestionServiceImpl implements SuggestionService {
     private static final Logger LOGGER = LoggerFactory.getLogger(SuggestionServiceImpl.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/TextSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/suggestion/TextSuggestionServiceImpl.java
@@ -12,8 +12,6 @@ import java.util.regex.Pattern;
 
 /**
  * Perhaps in the future, we will tie this into an English dictionary. In the interim, we simply return the text as-is
- *
- * @author chrisburrell
  */
 public class TextSuggestionServiceImpl extends AbstractIgnoreMergedListSuggestionServiceImpl<TextSuggestion> {
     private static final Pattern INVALID_TEXT = Pattern.compile("[.:]\\d+");

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordAnalysisService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordAnalysisService.java
@@ -6,9 +6,6 @@ import org.crosswire.jsword.passage.Key;
 
 /**
  * Defines an interface for obtaining various stats on a passage.
- * 
- * @author chrisburrell
- * 
  */
 public interface JSwordAnalysisService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordMetadataService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordMetadataService.java
@@ -10,8 +10,6 @@ import org.crosswire.jsword.book.Book;
 
 /**
  * The service providing access to JSword. All JSword calls should preferably be placed in this service
- *
- * @author chrisburrell
  */
 public interface JSwordMetadataService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordModuleService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordModuleService.java
@@ -9,8 +9,6 @@ import org.crosswire.jsword.book.install.Installer;
 
 /**
  * The service providing access to JSword. All JSword calls should preferably be placed in this service
- *
- * @author chrisburrell
  */
 public interface JSwordModuleService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordPassageService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordPassageService.java
@@ -9,9 +9,6 @@ import org.crosswire.jsword.passage.Passage;
 
 /**
  * The service providing access to JSword. All JSword calls should preferably be placed in this service
- * 
- * @author chrisburrell
- * 
  */
 public interface JSwordPassageService {
     String REFERENCE_BOOK = "ESV_th";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordSearchService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordSearchService.java
@@ -9,8 +9,6 @@ import com.tyndalehouse.step.core.service.impl.SearchQuery;
 
 /**
  * Searches across jsword modules
- *
- * @author chrisburrell
  */
 public interface JSwordSearchService {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordVersificationService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/JSwordVersificationService.java
@@ -9,7 +9,6 @@ import org.crosswire.jsword.versification.Versification;
 /**
  * Some generally useful methods for dealing with versification.
  * 
- * @author chrisburrell
  */
 public interface JSwordVersificationService {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordAnalysisServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordAnalysisServiceImpl.java
@@ -26,8 +26,6 @@ import java.util.*;
 
 /**
  * The Class JSwordAnalysisServiceImpl.
- *
- * @author chrisburrell
  */
 public class JSwordAnalysisServiceImpl implements JSwordAnalysisService {
     static final String WORD_SPLIT = "[,./<>?!;:'\\[\\]\\{\\}!\"\\-\u2013 ()]+";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordMetadataServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordMetadataServiceImpl.java
@@ -28,8 +28,6 @@ import com.tyndalehouse.step.core.service.jsword.JSwordVersificationService;
 
 /**
  * Provides metadata for JSword modules
- *
- * @author chrisburrell
  */
 public class JSwordMetadataServiceImpl implements JSwordMetadataService {
     private static final String BOOK_CHAPTER_FORMAT = "%s %d";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordModuleServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordModuleServiceImpl.java
@@ -39,8 +39,6 @@ import static java.lang.String.format;
 
 /**
  * Service to manipulate modules
- *
- * @author chrisburrell
  */
 @Singleton
 public class JSwordModuleServiceImpl implements JSwordModuleService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordSearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordSearchServiceImpl.java
@@ -38,8 +38,6 @@ import java.util.regex.Pattern;
 
 /**
  * API to search across the data
- *
- * @author chrisburrell
  */
 @Singleton
 public class JSwordSearchServiceImpl implements JSwordSearchService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordVersificationServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordVersificationServiceImpl.java
@@ -19,9 +19,6 @@ import com.tyndalehouse.step.core.service.jsword.JSwordVersificationService;
 
 /**
  * Deals with the versification
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class JSwordVersificationServiceImpl implements JSwordVersificationService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/OriginalWordSuggestionService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/OriginalWordSuggestionService.java
@@ -7,9 +7,6 @@ import com.tyndalehouse.step.core.models.search.SuggestionType;
 
 /**
  * Interface to search for relevant suggestions for a given input, whether unicode or transliterations
- * 
- * @author chrisburrell
- * 
  */
 public interface OriginalWordSuggestionService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/SubjectEntrySearchService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/SubjectEntrySearchService.java
@@ -6,9 +6,6 @@ import com.tyndalehouse.step.core.models.OsisWrapper;
 
 /**
  * Searches for a specific subject
- * 
- * @author chrisburrell
- * 
  */
 public interface SubjectEntrySearchService {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/SubjectSearchService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/SubjectSearchService.java
@@ -10,9 +10,6 @@ import java.util.List;
 
 /**
  * Searches for a specific subject
- * 
- * @author chrisburrell
- * 
  */
 public interface SubjectSearchService {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/OriginalWordSuggestionServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/OriginalWordSuggestionServiceImpl.java
@@ -28,8 +28,6 @@ import static com.tyndalehouse.step.core.utils.language.HebrewUtils.isHebrewText
 
 /**
  * Runs all original word searches
- *
- * @author chrisburrell
  */
 @Singleton
 public class OriginalWordSuggestionServiceImpl implements OriginalWordSuggestionService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
@@ -66,8 +66,6 @@ import static java.lang.Character.isDigit;
 
 /**
  * A federated search service implementation. see {@link SearchService}
- *
- * @author chrisburrell
  */
 @Singleton
 public class SearchServiceImpl implements SearchService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectEntryServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectEntryServiceImpl.java
@@ -39,8 +39,6 @@ import java.util.Set;
 
 /**
  * Retrieves the entries from a subject search
- *
- * @author chrisburrell
  */
 @Singleton
 public class SubjectEntryServiceImpl extends AbstractSubjectSearchServiceImpl implements SubjectEntrySearchService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectSearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SubjectSearchServiceImpl.java
@@ -55,8 +55,6 @@ import static com.tyndalehouse.step.core.utils.StringUtils.isBlank;
 
 /**
  * Searches for a subject
- *
- * @author chrisburrell
  */
 @Singleton
 public class SubjectSearchServiceImpl extends AbstractSubjectSearchServiceImpl implements SubjectSearchService {

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/AbstractStepGuiceModule.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/AbstractStepGuiceModule.java
@@ -11,7 +11,6 @@ import com.google.inject.name.Names;
 /**
  * A colletion of utilities to read property files
  * 
- * @author chrisburrell
  */
 public abstract class AbstractStepGuiceModule extends AbstractModule {
     private final String propertyFileUrl;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/ConversionUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/ConversionUtils.java
@@ -10,7 +10,6 @@ import org.joda.time.LocalDateTime;
 /**
  * Utilities to convert from one form to another
  * 
- * @author chrisburrell
  */
 public final class ConversionUtils {
     private static final long MILLISECONDS_IN_MINUTE = 60000;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/HeadingsUtil.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/HeadingsUtil.java
@@ -13,8 +13,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Lengthens the name of a header
- *
- * @author chrisburrell
  */
 public final class HeadingsUtil {
     private static final Logger LOGGER = LoggerFactory.getLogger(HeadingsUtil.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/IOUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/IOUtils.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 /**
  * Some IO Utils for use in the STEP application.
  * 
- * @author chrisburrell
  */
 public final class IOUtils {
     private static final Logger LOG = LoggerFactory.getLogger(IOUtils.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/JSwordUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/JSwordUtils.java
@@ -24,9 +24,6 @@ import static org.crosswire.jsword.book.OSISUtil.OSIS_ELEMENT_VERSE;
 
 /**
  * a set of utility methods to manipulate the JSword objects coming out
- * 
- * @author chrisburrell
- * 
  */
 public final class JSwordUtils {
     private static final String BOOK_CHAPTER_OSIS_FORMAT = "%s.%d";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/LuceneUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/LuceneUtils.java
@@ -15,8 +15,6 @@ import java.util.Set;
 
 /**
  * Utilities to help with index reading
- *
- * @author chrisburrell
  */
 public final class LuceneUtils {
     private static final int MAX_TRACK = 55;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/SortingUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/SortingUtils.java
@@ -7,8 +7,6 @@ import java.util.Locale;
 
 /**
  * a set of utility methods to sort various collections
- *
- * @author chrisburrell
  */
 public final class SortingUtils {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringConversionUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringConversionUtils.java
@@ -20,8 +20,6 @@ import static com.tyndalehouse.step.core.utils.language.HebrewUtils.removeHebrew
 
 /**
  * A collection of utility methods enabling us to convert Strings, references one way or another.
- *
- * @author chrisburrell
  */
 public final class StringConversionUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(StringConversionUtils.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/StringUtils.java
@@ -9,8 +9,6 @@ import java.util.regex.Pattern;
 /**
  * To avoid having large libraries, we provide here a small set of methods that can be used to perform various
  * string operations
- *
- * @author chrisburrell
  */
 public final class StringUtils {
     private static final Map<String, Pattern> PATTERNS = new HashMap<String, Pattern>();

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/ValidateUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/ValidateUtils.java
@@ -9,9 +9,6 @@ import java.util.Locale;
 
 /**
  * Checks various assertions and throws the exception: {@link ValidationException}
- * 
- * @author chrisburrell
- * 
  */
 public final class ValidateUtils {
     /** can't instantiate */

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/XslHelper.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/XslHelper.java
@@ -6,9 +6,6 @@ import static java.lang.String.format;
 
 /**
  * A helper class for use during XSL transformations
- * 
- * @author chrisburrell
- * 
  */
 public final class XslHelper {
     private static final int APPROX_ANCHOR_LENGTH = 56;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/ContemporaryLanguageUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/ContemporaryLanguageUtils.java
@@ -4,9 +4,6 @@ import java.util.Locale;
 
 /**
  * Utilities for doing Hebrew transliteration
- * 
- * @author chrisburrell
- * 
  */
 public final class ContemporaryLanguageUtils {
     /** prevent instantiation */

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/GreekUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/GreekUtils.java
@@ -10,9 +10,6 @@ import com.tyndalehouse.step.core.utils.language.transliteration.Transliteration
 
 /**
  * Utilities for doing Hebrew transliteration
- * 
- * @author chrisburrell
- * 
  */
 public final class GreekUtils {
     private static final int PERISPOMENI = 0x0342;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/HebrewUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/HebrewUtils.java
@@ -11,8 +11,6 @@ import java.util.List;
 
 /**
  * Utilities for doing Hebrew transliteration
- *
- * @author chrisburrell
  */
 public final class HebrewUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(HebrewUtils.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/ConsonantType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/ConsonantType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.utils.language.hebrew;
 
 /**
  * Hebrew consonant types
- * 
- * @author chrisburrell
- * 
  */
 public enum ConsonantType {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/HebrewLetter.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/HebrewLetter.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.utils.language.hebrew;
 
 /**
  * A collection of enums to identify properties of the letter
- * 
- * @author chrisburrell
- * 
  */
 public class HebrewLetter {
     private HebrewLetterType hebrewLetterType = null;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/HebrewLetterType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/HebrewLetterType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.utils.language.hebrew;
 
 /**
  * Distinguishes between consonant and vowels
- * 
- * @author chrisburrell
- * 
  */
 public enum HebrewLetterType {
     /** hebrew consonant */

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/SoundingType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/SoundingType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.utils.language.hebrew;
 
 /**
  * Vowel types
- * 
- * @author chrisburrell
- * 
  */
 public enum SoundingType {
     /** sounding */

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/VowelLengthType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/VowelLengthType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.utils.language.hebrew;
 
 /**
  * Vowel types
- * 
- * @author chrisburrell
- * 
  */
 public enum VowelLengthType {
     /** long sounding vowel */

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/VowelStressType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/hebrew/VowelStressType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.utils.language.hebrew;
 
 /**
  * Vowel types
- * 
- * @author chrisburrell
- * 
  */
 public enum VowelStressType {
     /** Stressed emphasis */

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/transliteration/StringToStringRule.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/transliteration/StringToStringRule.java
@@ -5,9 +5,6 @@ import java.util.List;
 
 /**
  * Replaces a single character with a set of options
- * 
- * @author chrisburrell
- * 
  */
 public class StringToStringRule implements TransliterationRule {
     private final char[] s;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/transliteration/TransliterationOption.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/transliteration/TransliterationOption.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.core.utils.language.transliteration;
 /**
  * An option in a transliteration is a String that is built up, plus the current position tracked to the
  * original word
- * 
- * @author chrisburrell
- * 
  */
 public class TransliterationOption {
     private int nextValidPosition;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/transliteration/TransliterationRule.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/language/transliteration/TransliterationRule.java
@@ -2,11 +2,6 @@ package com.tyndalehouse.step.core.utils.language.transliteration;
 
 import java.util.List;
 
-/**
- * 
- * @author chrisburrell
- * 
- */
 public interface TransliterationRule {
     /**
      * @param prefixes a list of existing prefixes to append to

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/InterleavingProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/InterleavingProvider.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.xsl;
 
 /**
  * Defines the methods useful for xsl transforms when interleaving
- * 
- * @author chrisburrell
- * 
  */
 public interface InterleavingProvider {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/InterlinearProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/InterlinearProvider.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.core.xsl;
 /**
  * An individual interlinear provider that cross-references text passed in using verse, strong, and morphology
  * information
- * 
- * @author chrisburrell
- * 
  */
 public interface InterlinearProvider {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/MultiInterlinearProvider.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/MultiInterlinearProvider.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.xsl;
 
 /**
  * the Interface that a Mutli interlinear provider shall abide to
- * 
- * @author chrisburrell
- * 
  */
 public interface MultiInterlinearProvider {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/XslConversionType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/XslConversionType.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.xsl;
 
 /**
  * Defines which types of XSL stylesheets are available
- * 
- * @author chrisburrell
- * 
  */
 public enum XslConversionType {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/ColorCoderProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/ColorCoderProviderImpl.java
@@ -41,7 +41,6 @@ import com.tyndalehouse.step.core.data.EntityManager;
  * ie anything ending GSM GSN GSF GPM GPN or GPF or DSM DSN DSF DPM DPN or DPF
  * 
  * 
- * @author chrisburrell
  */
 public class ColorCoderProviderImpl {
     private static final Logger LOGGER = LoggerFactory.getLogger(ColorCoderProviderImpl.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/DualKey.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/DualKey.java
@@ -8,8 +8,6 @@ import static java.lang.String.format;
  * 
  * @param <T> the first part of the key
  * @param <S> the second part of the key
- * @author chrisburrell
- * 
  */
 public class DualKey<T, S> {
     private final T t;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImpl.java
@@ -8,9 +8,6 @@ import com.tyndalehouse.step.core.xsl.InterleavingProvider;
 
 /**
  * Provides the headings for any interleaved passage
- *
- * @author chrisburrell
- *
  */
 public class InterleavingProviderImpl implements InterleavingProvider {
     private String[] versions;

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImpl.java
@@ -30,8 +30,6 @@ import static java.lang.String.format;
  * This object is not purposed to be used as a singleton. It builds up textual information on initialisation, and is
  * specific to requests. On initialisation, the OSIS XML is retrieved and iterated through to find all strong/morph
  * candidates
- *
- * @author chrisburrell
  */
 public class InterlinearProviderImpl implements InterlinearProvider {
 

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/MultiInterlinearProviderImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/MultiInterlinearProviderImpl.java
@@ -22,8 +22,6 @@ import static com.tyndalehouse.step.core.utils.StringUtils.split;
 
 /**
  * This implementation will support multiple versions, so each of the methods is keyed by version requested.
- *
- * @author chrisburrell
  */
 public class MultiInterlinearProviderImpl implements MultiInterlinearProvider {
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/Word.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/xsl/impl/Word.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.core.xsl.impl;
 
 /**
  * An interlinear word can be partial if tagged with an H00, which then causes two words to be looked up...
- * 
- * @author chrisburrell
- * 
  */
 public class Word {
     private final String text;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/DirectoryInstallerTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/DirectoryInstallerTest.java
@@ -25,9 +25,6 @@ import com.tyndalehouse.step.core.utils.TestUtils;
 
 /**
  * Test installations from a directory
- * 
- * @author chrisburrell
- * 
  */
 public class DirectoryInstallerTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(DirectoryInstallerTest.class);

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/common/PartialDateTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/common/PartialDateTest.java
@@ -10,9 +10,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * Checks different types of parsing functionality for parsing dates
- * 
- * @author chrisburrell
- * 
  */
 public class PartialDateTest {
     /** tests null dates */

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/create/LoaderTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/create/LoaderTest.java
@@ -27,9 +27,6 @@ import com.tyndalehouse.step.core.utils.TestUtils;
 
 /**
  * Tests the loading of the all loaders
- * 
- * @author chrisburrell
- * 
  */
 @RunWith(MockitoJUnitRunner.class)
 public class LoaderTest {

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestEntityIndexReaderImpl.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestEntityIndexReaderImpl.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.data.EntityConfiguration;
 
 /**
  * Memory only lucene indexes...
- * 
- * @author chrisburrell
- * 
  */
 public class TestEntityIndexReaderImpl extends EntityIndexReaderImpl {
     private static final Logger LOGGER = LoggerFactory.getLogger(TestEntityIndexReaderImpl.class);

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestEntityIndexWriterImpl.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestEntityIndexWriterImpl.java
@@ -10,9 +10,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
 
 /**
  * A test version
- * 
- * @author chrisburrell
- * 
  */
 public class TestEntityIndexWriterImpl extends EntityIndexWriterImpl {
 

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestEntityManager.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestEntityManager.java
@@ -11,9 +11,6 @@ import com.tyndalehouse.step.core.service.jsword.JSwordPassageService;
 
 /**
  * a test entity manager, which gives us indexes in memory
- * 
- * @author chrisburrell
- * 
  */
 public class TestEntityManager extends EntityManagerImpl {
     private final Map<String, EntityIndexReader> indexReaders;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestLuceneIndexDirectory.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/entities/impl/TestLuceneIndexDirectory.java
@@ -9,9 +9,6 @@ import org.apache.lucene.store.RAMDirectory;
 
 /**
  * A singleton to help locate the lucene indexes in testing
- * 
- * @author chrisburrell
- * 
  */
 public final class TestLuceneIndexDirectory {
     private static Map<String, Directory> directories = new HashMap<String, Directory>();

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/processors/NaveProcessorTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/processors/NaveProcessorTest.java
@@ -4,9 +4,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * @author chrisburrell
- */
 public class NaveProcessorTest {
     @Test
     public void testStripAlternatives()  {

--- a/step-core/src/test/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProviderTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/guice/providers/DefaultInstallersProviderTest.java
@@ -8,9 +8,6 @@ import org.junit.Test;
 
 /**
  * Test properties are loaded properly and construct a installer capable of downloading books off the internet
- * 
- * @author chrisburrell
- * 
  */
 public class DefaultInstallersProviderTest {
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/models/LookupOptionTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/models/LookupOptionTest.java
@@ -8,9 +8,6 @@ import java.util.Set;
 
 import static org.junit.Assert.assertTrue;
 
-/**
- * @author chrisburrell
- */
 public class LookupOptionTest {
     /**
      * Tests that options are unique by UI Name

--- a/step-core/src/test/java/com/tyndalehouse/step/core/prebuild/DownloadJSwordBiblesPreReq.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/prebuild/DownloadJSwordBiblesPreReq.java
@@ -19,9 +19,6 @@ import com.tyndalehouse.step.core.utils.TestUtils;
 
 /**
  * Downloads the jsword bible versions
- * 
- * @author chrisburrell
- * 
  */
 public class DownloadJSwordBiblesPreReq {
     private static final Logger LOGGER = LoggerFactory.getLogger(DownloadJSwordBiblesPreReq.class);

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/helpers/VersionResolverTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/helpers/VersionResolverTest.java
@@ -12,10 +12,7 @@ import org.crosswire.jsword.book.Books;
 import org.junit.Before;
 import org.junit.Test;
 
-/**
- * @author chrisburrell
- * 
- */
+
 public class VersionResolverTest {
 
     private VersionResolver resolver;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/helpers/VersionResolverTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/helpers/VersionResolverTest.java
@@ -12,7 +12,6 @@ import org.crosswire.jsword.book.Books;
 import org.junit.Before;
 import org.junit.Test;
 
-
 public class VersionResolverTest {
 
     private VersionResolver resolver;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/IndividualSearchTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/IndividualSearchTest.java
@@ -6,9 +6,6 @@ import org.junit.Test;
 
 /**
  * tests for {@link IndividualSearch}
- * 
- * @author chrisburrell
- * 
  */
 public class IndividualSearchTest {
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/UserServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/UserServiceImplTest.java
@@ -12,9 +12,6 @@ import org.junit.Test;
 
 /**
  * Checks a user is valid
- * 
- * @author chrisburrell
- * 
  */
 public class UserServiceImplTest {
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/VocabularyServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/impl/VocabularyServiceImplTest.java
@@ -10,9 +10,6 @@ import com.tyndalehouse.step.core.data.entities.impl.EntityManagerImpl;
 
 /**
  * Tests {@link VocabularyServiceImpl}
- * 
- * @author chrisburrell
- * 
  */
 public class VocabularyServiceImplTest {
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordSearchServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordSearchServiceImplTest.java
@@ -26,7 +26,6 @@ import com.tyndalehouse.step.core.utils.TestUtils;
 /**
  * Tests the various searches
  * 
- * @author chrisburrell
  */
 @SuppressWarnings("unchecked")
 public class JSwordSearchServiceImplTest {

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImplTest.java
@@ -37,8 +37,6 @@ import com.tyndalehouse.step.core.utils.TestUtils;
 
 /**
  * Search service testing
- *
- * @author chrisburrell
  */
 public class SearchServiceImplTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(SearchServiceImplTest.class);

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringConversionUtilsTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringConversionUtilsTest.java
@@ -13,8 +13,6 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Tests the utility method for converting strings
- *
- * @author chrisburrell
  */
 public class StringConversionUtilsTest {
     private static final Logger LOG = LoggerFactory.getLogger(StringConversionUtilsTest.class);

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringUtilsTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringUtilsTest.java
@@ -6,9 +6,6 @@ import org.junit.Test;
 
 /**
  * Tests the {@link StringUtils} class
- * 
- * @author chrisburrell
- * 
  */
 public class StringUtilsTest {
     /** test normal split condition */

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/TestUtils.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/TestUtils.java
@@ -15,9 +15,6 @@ import com.tyndalehouse.step.core.service.jsword.impl.JSwordVersificationService
 
 /**
  * static utilities for testing, creating entities, etc.
- * 
- * @author chrisburrell
- * 
  */
 public final class TestUtils {
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/language/GreekUtilsTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/language/GreekUtilsTest.java
@@ -14,9 +14,6 @@ import org.junit.Test;
 
 /**
  * Greek utils tests
- * 
- * @author chrisburrell
- * 
  */
 public class GreekUtilsTest {
     /** test the regex parses and removes the appropriate characters */

--- a/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImplTest.java
@@ -15,9 +15,6 @@ import com.tyndalehouse.step.core.service.jsword.JSwordVersificationService;
 
 /**
  * A simple test class to test to the provider
- * 
- * @author chrisburrell
- * 
  */
 public class InterleavingProviderImplTest {
 

--- a/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterlinearProviderImplTest.java
@@ -21,9 +21,6 @@ import org.junit.Test;
 
 /**
  * A simple test class to test to the provider
- * 
- * @author chrisburrell
- * 
  */
 public class InterlinearProviderImplTest {
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/MultiInterlinearProviderImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/MultiInterlinearProviderImplTest.java
@@ -8,9 +8,6 @@ import org.junit.Test;
 
 /**
  * Tests the version splitters
- * 
- * @author chrisburrell
- * 
  */
 public class MultiInterlinearProviderImplTest {
     /**

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/UnicodeFileReaderToProperties.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/UnicodeFileReaderToProperties.java
@@ -13,9 +13,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
-/**
- * @author chrisburrell
- */
 public class UnicodeFileReaderToProperties {
     public static void main(String[] args) throws IOException {
         Properties p = new Properties();

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter.java
@@ -27,9 +27,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.Date;
 
-/**
- * @author chrisburrell
- */
 
 public class BerkeleyOutputConverter {
     private static final Map<String, String> entries = new HashMap<String, String>(12000);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter2.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputConverter2.java
@@ -24,9 +24,6 @@ import java.util.List;
 import java.util.Map;
 import java.lang.String;
 
-/**
- * @author chrisburrell
- */
 public class BerkeleyOutputConverter2 {
     private static final Map<String, String> entries = new HashMap<String, String>(12000);
     private static final Map<String, String> greekEntries = new HashMap<String, String>(12000);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputToTaggingFormat.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BerkeleyOutputToTaggingFormat.java
@@ -14,9 +14,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-/**
- * @author chrisburrell
- */
 public class BerkeleyOutputToTaggingFormat {
     private static final Map<String, String> entries = new HashMap<String, String>(12000);
 

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BibleAnalysis.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/BibleAnalysis.java
@@ -31,9 +31,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * A tool to anaylise frequencies of each word in the bible
- * 
- * @author chrisburrell
- * 
  */
 @SuppressWarnings("unchecked")
 public class BibleAnalysis {

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ChiasticStructure.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ChiasticStructure.java
@@ -16,9 +16,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.*;
 
-/**
- * @author chrisburrell
- */
 public class ChiasticStructure {
     private static Logger LOGGER = LoggerFactory.getLogger(ChiasticStructure.class);
     private Map<String, String> entries = new HashMap<String, String>(256);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ExactMatch.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ExactMatch.java
@@ -4,9 +4,6 @@ package com.tyndalehouse.step.tools.analysis;
 /**
  * when the word in question is found in exactly the same number of verses and exactly the same verses as in
  * the original greek word
- * 
- * @author chrisburrell
- * 
  */
 public class ExactMatch {
     int numVersesForStrong;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ModuleToStrong.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/analysis/ModuleToStrong.java
@@ -9,9 +9,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.regex.Pattern;
 
-/**
- * @author chrisburrell
- */
 public class ModuleToStrong {
     private static final Pattern PUNCTUATION = Pattern.compile("[—,.;*:'\\[\\]!\"`?’‘()-]+");
 

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/conversion/ConversionException.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/conversion/ConversionException.java
@@ -1,8 +1,5 @@
 package com.tyndalehouse.step.tools.conversion;
 
-/**
- * @author chrisburrell
- */
 public class ConversionException extends RuntimeException {
     public ConversionException(final String s) {
         super(s);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/conversion/OsisConversionUtils.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/conversion/OsisConversionUtils.java
@@ -22,9 +22,6 @@ import java.io.StringWriter;
 import java.util.Queue;
 import java.util.concurrent.LinkedBlockingQueue;
 
-/**
- * @author chrisburrell
- */
 public class OsisConversionUtils {
     private static final String ERROR = "<!-- ERROR -->";
     private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(OsisConversionUtils.class);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/conversion/XmlToOSIS.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/conversion/XmlToOSIS.java
@@ -30,8 +30,6 @@ import java.util.*;
 
 /**
  * Joins all the Biblica XML files together
- *
- * @author chrisburrell
  */
 public class XmlToOSIS {
     private final String otPath;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/EsvStrongNumberReport.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/EsvStrongNumberReport.java
@@ -25,9 +25,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Strong number reports against each verse
- * 
- * @author chrisburrell
- * 
  */
 public class EsvStrongNumberReport {
     private static final Logger LOGGER = LoggerFactory.getLogger(EsvStrongNumberReport.class);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/Tagging.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/Tagging.java
@@ -1,9 +1,6 @@
 package com.tyndalehouse.step.tools.esv;
 
-/**
- * @author chrisburrell
- * 
- */
+
 public class Tagging {
     private String ref;
     private String originalTaggedText;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/Tagging.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/Tagging.java
@@ -1,6 +1,5 @@
 package com.tyndalehouse.step.tools.esv;
 
-
 public class Tagging {
     private String ref;
     private String originalTaggedText;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/deprecated/EsvOsisEnricher.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/esv/deprecated/EsvOsisEnricher.java
@@ -27,7 +27,6 @@ import org.slf4j.LoggerFactory;
  * Reads in an xml file and tries to track progress with a tagging sheet, enriching where it can
  *
  * @deprecated
- * @author chrisburrell
  */
 @Deprecated
 public class EsvOsisEnricher {

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/international/CheckLanguageFiles.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/international/CheckLanguageFiles.java
@@ -23,8 +23,6 @@ import java.util.regex.Pattern;
 
 /**
  * Checks language files all contain the right number of markers
- *
- * @author chrisburrell
  */
 public class CheckLanguageFiles {
     public static final Map<String, Set<String>> MARKERS = new LinkedHashMap<String, Set<String>>();

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/ConvertXmlToOSISModule.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/ConvertXmlToOSISModule.java
@@ -13,9 +13,6 @@ import java.io.*;
 import java.util.Properties;
 import java.util.concurrent.*;
 
-/**
- * @author chrisburrell
- */
 public class ConvertXmlToOSISModule {
     private static final Logger LOGGER = LoggerFactory.getLogger(ConvertXmlToOSISModule.class);
     private static File SOURCE_DIRECTORY = new File("c:\\dev\\projects\\ebible\\downloads");

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/ExtractHeaderInformationSax.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/ExtractHeaderInformationSax.java
@@ -4,9 +4,6 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
-/**
- * @author chrisburrell
- */
 public class ExtractHeaderInformationSax extends DefaultHandler {
     private boolean titleFlag, descriptionFlag, copyrightFlag, versificationFlag, languageFlag, licenseFlag, 
             headerFlag, aboutFlag, revisionFlag;

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/IndexAll.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/IndexAll.java
@@ -10,9 +10,6 @@ import com.tyndalehouse.step.core.service.BibleInformationService;
 
 /**
  * Indexes all modules
- * 
- * @author chrisburrell
- *
  */
 public class IndexAll {
     /**

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/IndexModule.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/modules/IndexModule.java
@@ -11,9 +11,6 @@ import org.crosswire.jsword.book.sword.ConfigValueInterceptor;
 
 /**
  * Indexes a single module modules
- * 
- * @author chrisburrell
- *
  */
 public class IndexModule {
     /**

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/nave/NaveTransforming.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/nave/NaveTransforming.java
@@ -16,9 +16,6 @@ import com.tyndalehouse.step.core.utils.StringUtils;
 
 /**
  * transforming the nave's file
- * 
- * @author chrisburrell
- * 
  */
 @SuppressWarnings("unused")
 public class NaveTransforming {

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/nave/NaveXmlDataProcessor.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/nave/NaveXmlDataProcessor.java
@@ -20,9 +20,6 @@ import org.jdom2.input.SAXBuilder;
 
 /**
  * transforming the nave's file
- * 
- * @author chrisburrell
- * 
  */
 
 @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/BibleInfoReader.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/BibleInfoReader.java
@@ -22,9 +22,6 @@ import java.util.List;
 
 /**
  * Reads an osis ref in a module
- * 
- * @author chrisburrell
- * 
  */
 public class BibleInfoReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(BibleInfoReader.class);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/CanonicalOsisData.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/CanonicalOsisData.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.tools.osis;
 import org.crosswire.jsword.book.*;
 import org.crosswire.jsword.passage.NoSuchKeyException;
 
-/**
- * @author chrisburrell
- */
 public class CanonicalOsisData {
     public static void main(String[] args) throws BookException, NoSuchKeyException {
         final Book kjv = Books.installed().getBook("KJV");

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/InterleavedOsisReader.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/InterleavedOsisReader.java
@@ -22,9 +22,6 @@ import com.tyndalehouse.step.core.utils.TestUtils;
 
 /**
  * Reads an osis ref in a module
- * 
- * @author chrisburrell
- * 
  */
 public class InterleavedOsisReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(InterleavedOsisReader.class);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/OHBParser.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/OHBParser.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 
 /**
  * Strips out the '/' character from the original source.
- * @author chrisburrell
  */
 public class OHBParser {
     /**

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/OsisReader.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/OsisReader.java
@@ -28,9 +28,6 @@ import com.tyndalehouse.step.core.utils.TestUtils;
 
 /**
  * Reads an osis ref in a module
- * 
- * @author chrisburrell
- * 
  */
 public class OsisReader {
     private static final Logger LOGGER = LoggerFactory.getLogger(OsisReader.class);

--- a/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/Verse.java
+++ b/step-tools/src/main/java/com/tyndalehouse/step/tools/osis/Verse.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.tools.osis;
 
 /**
  * Verse image info
- * 
- * @author chrisburrell
- * 
  */
 public class Verse {
     private final String ref;

--- a/step-web-test/src/test/java/com/tyndalehouse/step/e2e/fragments/MenuOperations.java
+++ b/step-web-test/src/test/java/com/tyndalehouse/step/e2e/fragments/MenuOperations.java
@@ -17,8 +17,6 @@ import com.google.common.base.Predicate;
 
 /**
  * Helper for menu operations
- *
- * @author chrisburrell
  */
 public final class MenuOperations {
     /**

--- a/step-web-test/src/test/java/com/tyndalehouse/step/e2e/framework/WebDriverUtils.java
+++ b/step-web-test/src/test/java/com/tyndalehouse/step/e2e/framework/WebDriverUtils.java
@@ -3,9 +3,6 @@ package com.tyndalehouse.step.e2e.framework;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 
-/**
- * @author chrisburrell
- */
 public class WebDriverUtils {
     /**
      * Selects all content in the text box

--- a/step-web-test/src/test/java/com/tyndalehouse/step/e2e/tests/StepDisplayOptionsTest.java
+++ b/step-web-test/src/test/java/com/tyndalehouse/step/e2e/tests/StepDisplayOptionsTest.java
@@ -17,9 +17,6 @@ import com.tyndalehouse.step.e2e.framework.WebDriverTest;
 
 /**
  * Tests basic pasage functionality
- * 
- * @author chrisburrell
- * 
  */
 @RunWith(Parameterized.class)
 public class StepDisplayOptionsTest extends WebDriverTest {

--- a/step-web-test/src/test/java/com/tyndalehouse/step/e2e/tests/StepPassageTest.java
+++ b/step-web-test/src/test/java/com/tyndalehouse/step/e2e/tests/StepPassageTest.java
@@ -8,9 +8,6 @@ import com.tyndalehouse.step.e2e.framework.WebDriverTest;
 
 /**
  * Tests basic pasage functionality
- * 
- * @author chrisburrell
- * 
  */
 public class StepPassageTest extends WebDriverTest {
 

--- a/step-web-test/src/test/java/com/tyndalehouse/step/e2e/tests/regression/TopMenuWithoutCookiesTest.java
+++ b/step-web-test/src/test/java/com/tyndalehouse/step/e2e/tests/regression/TopMenuWithoutCookiesTest.java
@@ -8,9 +8,6 @@ import com.tyndalehouse.step.e2e.fragments.MenuOperations;
 import com.tyndalehouse.step.e2e.fragments.PageOperations;
 import com.tyndalehouse.step.e2e.framework.WebDriverTest;
 
-/**
- * @author chrisburrell
- */
 public class TopMenuWithoutCookiesTest extends WebDriverTest {
     @Test
     public void testOnlyOneTickInLevelMenu() {

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/ExternalPoweredByFilter.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/ExternalPoweredByFilter.java
@@ -13,7 +13,6 @@ import javax.servlet.ServletResponse;
 /**
  * Adds a filter, and restricts the types of calls allowed.
  * 
- * @author chrisburrell
  */
 @Singleton
 public class ExternalPoweredByFilter implements Filter {

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/HashBangFragmentFilter.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/HashBangFragmentFilter.java
@@ -16,9 +16,6 @@ import javax.servlet.ServletResponse;
 
 /**
  * Intercepts and works out whether JSword has been installed with modules...
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class HashBangFragmentFilter implements Filter {

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/SetupRedirectFilter.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/SetupRedirectFilter.java
@@ -10,8 +10,6 @@ import java.io.IOException;
 
 /**
  * Intercepts and works out whether STEP has finished the installation process
- *
- * @author chrisburrell
  */
 @Singleton
 public class SetupRedirectFilter implements Filter {

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/StepServletConfig.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/StepServletConfig.java
@@ -39,8 +39,6 @@ import java.util.Locale;
 
 /**
  * Configures the listener for the web app to return the injector used to configure the whole of the application.
- *
- * @author chrisburrell
  */
 
 public class StepServletConfig extends GuiceServletContextListener {

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/StepWebModule.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/StepWebModule.java
@@ -15,8 +15,6 @@ import javax.inject.Singleton;
 /**
  * This module serves to inject data that is specific to the servlet layer. The purpose of it is therefore to abstract
  * away the identity of it being a java web servlet serving the page.
- *
- * @author chrisburrell
  */
 public class StepWebModule extends AbstractStepGuiceModule {
     private static final String GUICE_PROPERTIES = "/step.web.properties";

--- a/step-web/src/main/java/com/tyndalehouse/step/guice/providers/ClientSessionProvider.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/guice/providers/ClientSessionProvider.java
@@ -19,9 +19,6 @@ import com.tyndalehouse.step.models.WebSessionImpl;
 /**
  * This object is request-scoped, meaning it is new for every request. It is a way to return the jsessionId at
  * runtime
- * 
- * @author chrisburrell
- * 
  */
 @RequestScoped
 public class ClientSessionProvider implements Provider<ClientSession> {

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/AdvancedSearchStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/AdvancedSearchStepRequest.java
@@ -10,7 +10,6 @@ import com.tyndalehouse.step.core.models.ClientSession;
 /**
  * A WebCookieRequest stores information from the request and the cookie for easy use in the jsp page.
  * 
- * @author chrisburrell
  */
 // CHECKSTYLE:OFF
 public class AdvancedSearchStepRequest extends WebStepRequest {

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/PassageSearchRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/PassageSearchRequest.java
@@ -8,8 +8,6 @@ import java.util.List;
 
 /**
  * A helper utils for outputting search entries
- *
- * @author chrisburrell
  */
 public class PassageSearchRequest {
     private final SearchController search;

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/PrefaceStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/PrefaceStepRequest.java
@@ -12,9 +12,6 @@ import com.tyndalehouse.step.core.utils.IOUtils;
 
 /**
  * A WebCookieRequest stores information from the request and the cookie for easy use in the jsp page
- * 
- * @author chrisburrell
- * 
  */
 // CHECKSTYLE:OFF
 public class PrefaceStepRequest {

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/SimpleSearchStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/SimpleSearchStepRequest.java
@@ -10,7 +10,6 @@ import com.tyndalehouse.step.core.models.ClientSession;
 /**
  * A WebCookieRequest stores information from the request and the cookie for easy use in the jsp page.
  * 
- * @author chrisburrell
  */
 // CHECKSTYLE:OFF
 public class SimpleSearchStepRequest extends AbstractSearchStepRequest {

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionStepRequest.java
@@ -22,9 +22,6 @@ import java.util.ResourceBundle;
 
 /**
  * A WebCookieRequest stores information from the request and the cookie for easy use in the jsp page
- * 
- * @author chrisburrell
- * 
  */
 // CHECKSTYLE:OFF
 public class VersionStepRequest {

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionsStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/VersionsStepRequest.java
@@ -20,9 +20,6 @@ import com.tyndalehouse.step.core.utils.StringUtils;
 
 /**
  * A WebCookieRequest stores information from the request and the cookie for easy use in the jsp page
- * 
- * @author chrisburrell
- * 
  */
 // CHECKSTYLE:OFF
 public class VersionsStepRequest {

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/WebStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/WebStepRequest.java
@@ -23,8 +23,6 @@ import com.tyndalehouse.step.rest.controllers.BibleController;
 
 /**
  * A WebCookieRequest stores information from the request and the cookie for easy use in the jsp page
- *
- * @author chrisburrell
  */
 // CHECKSTYLE:OFF
 public class WebStepRequest {

--- a/step-web/src/main/java/com/tyndalehouse/step/jsp/WordSearchStepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/jsp/WordSearchStepRequest.java
@@ -10,7 +10,6 @@ import com.tyndalehouse.step.core.models.ClientSession;
 /**
  * A WebCookieRequest stores information from the request and the cookie for easy use in the jsp page.
  * 
- * @author chrisburrell
  */
 // CHECKSTYLE:OFF
 public class WordSearchStepRequest extends AbstractSearchStepRequest {

--- a/step-web/src/main/java/com/tyndalehouse/step/models/ClientOperation.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/ClientOperation.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.models;
 
 /**
  * a set of operations that should be performed by the client
- * 
- * @author chrisburrell
- * 
  */
 public enum ClientOperation {
     /**

--- a/step-web/src/main/java/com/tyndalehouse/step/models/ModulesForLanguageUser.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/ModulesForLanguageUser.java
@@ -6,9 +6,6 @@ import com.tyndalehouse.step.core.models.BibleVersion;
 
 /**
  * A list of modules returned to the user, with internationalized information
- * 
- * @author chrisburrell
- * 
  */
 public class ModulesForLanguageUser {
     private List<BibleVersion> versions;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/Note.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/Note.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.models;
 
 import java.util.List;
 
-/**
- * @author chrisburrell
- */
 public class Note {
     private String id;
     private String title;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/Place.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/Place.java
@@ -4,9 +4,6 @@ import com.tyndalehouse.step.core.data.EntityDoc;
 
 /**
  * A place
- * 
- * @author chrisburrell
- * 
  */
 public class Place {
     private Double latitude;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/TimelineTranslator.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/TimelineTranslator.java
@@ -9,7 +9,6 @@ import com.tyndalehouse.step.models.timeline.simile.SimileEvent;
 /**
  * A translator is able to convert timeline data into a form that is acceptable by the client
  * 
- * @author chrisburrell
  */
 public interface TimelineTranslator {
 

--- a/step-web/src/main/java/com/tyndalehouse/step/models/UiDefaults.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/UiDefaults.java
@@ -6,9 +6,6 @@ import com.google.inject.name.Named;
 
 /**
  * A POJO to hold properties
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class UiDefaults {

--- a/step-web/src/main/java/com/tyndalehouse/step/models/WebSessionImpl.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/WebSessionImpl.java
@@ -13,9 +13,6 @@ import javax.servlet.http.Part;
 
 /**
  * A web session which wraps around the jsession id...
- * 
- * @author chrisburrell
- * 
  */
 public class WebSessionImpl implements ClientSession {
     private String sessionId;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/info/Info.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/info/Info.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 /**
  * A set of information from various sources
- * 
- * @author chrisburrell
- * 
  */
 public class Info {
     private List<MorphInfo> morphInfos;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/info/MorphInfo.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/info/MorphInfo.java
@@ -6,9 +6,6 @@ import com.tyndalehouse.step.core.data.EntityDoc;
 
 /**
  * Captures information related to morphology
- * 
- * @author chrisburrell
- * 
  */
 
 public class MorphInfo implements Serializable {

--- a/step-web/src/main/java/com/tyndalehouse/step/models/info/VocabInfo.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/info/VocabInfo.java
@@ -12,8 +12,6 @@ import java.util.Map;
 
 /**
  * Captures information related to morphology
- *
- * @author chrisburrell
  */
 public class VocabInfo implements Serializable {
     private static final long serialVersionUID = 3478149117983010944L;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/DigestableTimeline.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/DigestableTimeline.java
@@ -2,9 +2,6 @@ package com.tyndalehouse.step.models.timeline;
 
 /**
  * Marks a structure that a UI can understand
- * 
- * @author chrisburrell
- * 
  */
 public interface DigestableTimeline {
 

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/EnhancedSimileEvent.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/EnhancedSimileEvent.java
@@ -7,9 +7,6 @@ import com.tyndalehouse.step.core.models.OsisWrapper;
 
 /**
  * An content-rich version of {@link SimileEvent}
- * 
- * @author chrisburrell
- * 
  */
 public class EnhancedSimileEvent implements Serializable {
     private static final long serialVersionUID = -3803861355000880742L;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileEvent.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileEvent.java
@@ -16,8 +16,6 @@ import java.util.Random;
  *         'link': 'http://www.allposters.com/-sp/Barfusserkirche-1924-Posters_i1116895_.htm'
  *         },
  * </pre>
- *
- * @author chrisburrell
  */
 public class SimileEvent implements DigestableTimeline, Serializable {
     private static final long serialVersionUID = -7725905171349065886L;

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineImpl.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineImpl.java
@@ -24,9 +24,6 @@ import com.tyndalehouse.step.models.timeline.DigestableTimeline;
  *     ]
  *     }
  * </pre>
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class SimileTimelineImpl implements DigestableTimeline {

--- a/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineTranslatorImpl.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/models/timeline/simile/SimileTimelineTranslatorImpl.java
@@ -13,9 +13,6 @@ import com.tyndalehouse.step.models.timeline.DigestableTimeline;
 
 /**
  * provides a way of
- * 
- * @author chrisburrell
- * 
  */
 public class SimileTimelineTranslatorImpl implements TimelineTranslator {
     private static final String SIMILE_DEFAULT_TIME_FORMAT = "iso8601";

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/BibleController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/BibleController.java
@@ -36,8 +36,6 @@ import com.yammer.metrics.annotation.Timed;
 
 /**
  * The controller for retrieving information on the bible or texts from the bible.
- *
- * @author chrisburrell
  */
 @Singleton
 public class BibleController {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/ImageController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/ImageController.java
@@ -28,9 +28,6 @@ import com.tyndalehouse.step.core.utils.IOUtils;
 
 /**
  * Serves the images by downloading them from a remote source if they do not already exist.
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class ImageController extends HttpServlet {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/IndexRedirect.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/IndexRedirect.java
@@ -13,9 +13,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
-/**
- * @author chrisburrell
- */
 @Singleton
 public class IndexRedirect extends HttpServlet {
     private static Logger LOGGER = LoggerFactory.getLogger(SearchPageController.class);

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/InternationalJsonController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/InternationalJsonController.java
@@ -20,8 +20,6 @@ import static com.tyndalehouse.step.core.utils.StringUtils.isNotBlank;
 
 /**
  * Serves the images by downloading them from a remote source if they do not already exist.
- *
- * @author chrisburrell
  */
 @Singleton
 public class InternationalJsonController extends HttpServlet {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/NotesController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/NotesController.java
@@ -13,8 +13,6 @@ import java.util.UUID;
 
 /**
  * Caters for persisting notes in the system
- *
- * @author chrisburrell
  */
 @Singleton
 public class NotesController {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SearchController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SearchController.java
@@ -35,8 +35,6 @@ import static com.tyndalehouse.step.core.utils.ValidateUtils.notBlank;
 
 /**
  * Caters for searching across the data base
- *
- * @author chrisburrell
  */
 @Singleton
 public class SearchController {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SearchPageController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SearchPageController.java
@@ -32,9 +32,6 @@ import java.util.*;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-/**
- * @author chrisburrell
- */
 @Singleton
 public class SearchPageController extends HttpServlet {
     public static String DEV_TOKEN = "UA-36285759-2";

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SetupController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SetupController.java
@@ -25,9 +25,6 @@ import com.tyndalehouse.step.core.utils.StringUtils;
 
 /**
  * The controller that will deal with any requests changing the behaviour of the application
- * 
- * @author chrisburrell
- * 
  */
 @RequestScoped
 public class SetupController {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SetupPageController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SetupPageController.java
@@ -33,9 +33,6 @@ import java.util.ResourceBundle;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
-/**
- * @author chrisburrell
- */
 @Singleton
 public class SetupPageController extends HttpServlet {
     private static final Pattern COMMA_SEPARATORS = Pattern.compile(",");

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SupportController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/SupportController.java
@@ -12,9 +12,6 @@ import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.util.concurrent.TimeUnit;
 
-/**
- * @author chrisburrell
- */
 @Singleton
 public class SupportController {
     private final SupportRequestService supportRequestService;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/TimelineController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/TimelineController.java
@@ -22,8 +22,6 @@ import static com.tyndalehouse.step.core.utils.ValidateUtils.notNull;
 
 /**
  * The timeline controller retrieves information about past events
- *
- * @author chrisburrell
  */
 @Singleton
 public class TimelineController {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/UserController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/UserController.java
@@ -13,9 +13,6 @@ import com.tyndalehouse.step.core.service.UserService;
 
 /**
  * Checking user is registered
- * 
- * @author chrisburrell
- * 
  */
 @RequestScoped
 public class UserController {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/external/V1Controller.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/controllers/external/V1Controller.java
@@ -15,7 +15,6 @@ import com.tyndalehouse.step.rest.controllers.BibleController;
 /**
  * Allows look up of passages.
  * 
- * @author chrisburrell
  */
 @Singleton
 public class V1Controller {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/AbstractAjaxController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/AbstractAjaxController.java
@@ -23,9 +23,6 @@ import java.util.ResourceBundle;
 
 import static java.lang.String.format;
 
-/**
- * @author chrisburrell
- */
 @MultipartConfig
 public abstract class AbstractAjaxController extends HttpServlet {
     private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAjaxController.class);

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientErrorResolver.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientErrorResolver.java
@@ -10,9 +10,6 @@ import com.tyndalehouse.step.models.ClientOperation;
 
 /**
  * Resolves errors based on the type of exception thrown
- * 
- * @author chrisburrell
- * 
  */
 @Singleton
 public class ClientErrorResolver {

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientHandledIssue.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ClientHandledIssue.java
@@ -6,9 +6,6 @@ import com.tyndalehouse.step.models.ClientOperation;
 
 /**
  * A client error, contains a message and an optional redirection operation
- * 
- * @author chrisburrell
- * 
  */
 public class ClientHandledIssue implements Serializable {
     private static final long serialVersionUID = -4354861806290828883L;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ControllerCacheKey.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ControllerCacheKey.java
@@ -3,7 +3,6 @@ package com.tyndalehouse.step.rest.framework;
 /**
  * This is a holder object for multiple variants of a cache key
  * 
- * @author chrisburrell
  */
 public class ControllerCacheKey {
     private final String methodKey;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/FrontController.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/FrontController.java
@@ -24,8 +24,6 @@ import static java.lang.String.format;
  * The FrontController acts like a minimal REST server. The paths are resolved as follows:
  * <p/>
  * /step-web/rest/controllerName/methodName/arg1/arg2/arg3
- *
- * @author chrisburrell
  */
 @MultipartConfig
 @Singleton

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ObjectMapperProvider.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/ObjectMapperProvider.java
@@ -6,9 +6,6 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 
-/**
- * @author chrisburrell
- */
 @Singleton
 public class ObjectMapperProvider implements Provider<ObjectMapper> {
     private static ObjectMapper objectMapper;

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/RequestUtils.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/RequestUtils.java
@@ -16,9 +16,6 @@ import com.tyndalehouse.step.core.models.ClientSession;
 
 /**
  * A set of utilities to deal with requests
- * 
- * @author chrisburrell
- * 
  */
 public final class RequestUtils {
     private static final Logger LOGGER = LoggerFactory.getLogger(RequestUtils.class);

--- a/step-web/src/main/java/com/tyndalehouse/step/rest/framework/StepRequest.java
+++ b/step-web/src/main/java/com/tyndalehouse/step/rest/framework/StepRequest.java
@@ -17,7 +17,6 @@ import com.tyndalehouse.step.core.exceptions.StepInternalException;
  * <p />
  * .
  * 
- * @author chrisburrell
  */
 public class StepRequest {
 

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/controllers/BibleControllerTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/controllers/BibleControllerTest.java
@@ -27,9 +27,6 @@ import com.tyndalehouse.step.guice.providers.ClientSessionProvider;
 
 /**
  * tests the bible controller
- * 
- * @author chrisburrell
- * 
  */
 @SuppressWarnings("unchecked")
 @RunWith(MockitoJUnitRunner.class)

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/framework/FrontControllerTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/framework/FrontControllerTest.java
@@ -40,8 +40,6 @@ import com.tyndalehouse.step.rest.controllers.BibleController;
 
 /**
  * tests the front controller parsing process
- *
- * @author chrisburrell
  */
 @SuppressWarnings("PMD.TooManyMethods")
 @RunWith(MockitoJUnitRunner.class)

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/framework/StepRequestTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/framework/StepRequestTest.java
@@ -16,9 +16,6 @@ import org.junit.Test;
 
 /**
  * Tests that cache keys are constructed correctly
- * 
- * @author chrisburrell
- * 
  */
 public class StepRequestTest {
     private static final String UTF_8_ENCODING = "UTF-8";


### PR DESCRIPTION
## Why

Since we use version control, it doesn't make sense to tag the author of code in comments around every function. We can remove a lot of redundant lines this way.