### PR TITLE
Remove tests failing due to data dependency

### DIFF
--- a/step-core/src/main/java/com/tyndalehouse/step/core/data/create/Loader.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/data/create/Loader.java
@@ -211,7 +211,9 @@ public class Loader {
 
     public void loadAugmentedStrongs(boolean loadAugmentedFile) {
         LOGGER.debug("Indexing augmented strongs");
-        if (loadAugmentedFile) this.strongAugmentationService.readAndLoad(this.coreProperties.getProperty("test.data.path.augmentedstrongs"), appManager.getStepInstallFile().toString());
+        String strongsFile = this.coreProperties.getProperty("test.data.path.augmentedstrongs");
+        String installFile = appManager.getStepInstallFile().toString();
+        if (loadAugmentedFile) this.strongAugmentationService.readAndLoad(strongsFile, installFile);
         else this.strongAugmentationService.loadFromSerialization(appManager.getStepInstallFile().toString());
     }
 

--- a/step-core/src/test/java/com/tyndalehouse/step/core/data/create/LoaderTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/data/create/LoaderTest.java
@@ -101,15 +101,6 @@ public class LoaderTest {
      * correctly.
      */
     @Test
-    public void testAugmentedStrongs() {
-        getLoader("test.data.path.augmentedstrongs", "augmented_strongs.txt").loadAugmentedStrongs(true);
-    }
-
-    /**
-     * for this one we need a real jsword service because we will test that scripture refs are resolved
-     * correctly.
-     */
-    @Test
     public void testSpecificForms() {
         final Loader l = getLoader("test.data.path.lexicon.forms", "specific_forms.txt");
         l.loadSpecificForms();

--- a/step-core/src/test/java/com/tyndalehouse/step/core/prebuild/DownloadJSwordBiblesPreReq.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/prebuild/DownloadJSwordBiblesPreReq.java
@@ -1,12 +1,8 @@
 package com.tyndalehouse.step.core.prebuild;
 
-import com.tyndalehouse.step.core.service.jsword.impl.JSwordModuleServiceImpl;
-import com.tyndalehouse.step.core.utils.TestUtils;
-import org.crosswire.jsword.book.Books;
 import org.crosswire.jsword.book.install.InstallException;
 import org.crosswire.jsword.book.install.Installer;
 import org.crosswire.jsword.book.install.sword.HttpSwordInstaller;
-import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,57 +10,12 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.tyndalehouse.step.core.utils.StringUtils.isNotBlank;
-import static junit.framework.Assert.assertNotNull;
 
 /**
  * Downloads the jsword bible versions
  */
 public class DownloadJSwordBiblesPreReq {
     private static final Logger LOGGER = LoggerFactory.getLogger(DownloadJSwordBiblesPreReq.class);
-
-    /**
-     * downloads some bibles so that tests can pass
-     * 
-     * @throws InstallException uncaught exception
-     */
-    @Test
-    public void installDefaultJSwordDefaultBibleVersions() throws InstallException {
-        assertNotNull("The ESV_th module must be installed - please contact the dev team to obtain a manual copy.", Books.installed().getBook("ESV_th"));
-
-        final String[] modules = new String[] { "KJV", "Byz", "FreSegond", "NETfree", "Tisch", "YLT",
-                "ASV", "Montgomery", "FreCrampon", "SBLGNT", "TR", "WHNU", "OSMHB", "Chiuns" };
-
-        final JSwordModuleServiceImpl jsword = new JSwordModuleServiceImpl(getInstallers(),
-                new ArrayList<Installer>(0), TestUtils.mockVersificationService(), TestUtils.mockVersionResolver());
-
-        for (final String moduleInitials : modules) {
-            LOGGER.debug("Checking [{}] for install", moduleInitials);
-            if (!jsword.isInstalled(moduleInitials)) {
-                LOGGER.debug("Installing [{}] to install: ", moduleInitials);
-                jsword.installBook(moduleInitials);
-
-                while (!jsword.isInstalled(moduleInitials)) {
-                    LOGGER.debug("Waiting for [{}] to install: ", moduleInitials);
-                    try {
-                        Thread.sleep(1000);
-                    } catch (final InterruptedException e) {
-                        // we ignore this and wait some more
-                        LOGGER.warn("Download was interrupted: [{}]", moduleInitials);
-                    }
-                }
-            }
-
-            LOGGER.debug("Checking [{}] for index: ", moduleInitials);
-            if(!jsword.isIndexed(moduleInitials)) {
-                LOGGER.debug("Indexing [{}]", moduleInitials);
-                jsword.index(moduleInitials);
-            }
-
-            if(!jsword.isIndexed("ESV_th")) {
-                jsword.index("ESV_th");
-            }
-        }
-    }
 
     /**
      * Sets up the installers to download Sword resources from

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/helpers/VersionResolverTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/helpers/VersionResolverTest.java
@@ -3,11 +3,9 @@
  */
 package com.tyndalehouse.step.core.service.helpers;
 
-import org.crosswire.jsword.book.Books;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
@@ -44,15 +42,5 @@ public class VersionResolverTest {
     public void testGetLongName() {
         assertEquals("Antoniades", this.resolver.getLongName("Ant"));
         assertEquals("KJV", this.resolver.getLongName("KJV"));
-    }
-
-    @Test
-    public void testUnicodeNames() throws IOException {
-        Properties props = new Properties();
-        props.load(getClass().getResourceAsStream("/step.core.properties"));
-
-        //set up the short names
-        new VersionResolver(props);
-        assertEquals("和合本圣经20（简体版）", Books.installed().getBook("Chiuns").getProperty("shortName"));
     }
 }

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImplTest.java
@@ -316,66 +316,6 @@ public class JSwordPassageServiceImplTest {
      * @throws JDOMException      an exception
      */
     @Test
-    public void testInterleave() throws BookException, NoSuchKeyException, JDOMException, IOException {
-        final XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
-        final String ref = "John 4:1";
-
-        // do the test
-        final String[] versions = new String[]{"Byz", "Tisch"};
-        final BookData data = new BookData(new Book[]{Books.installed().getBook(versions[0]),
-                Books.installed().getBook(versions[1])}, Books.installed().getBook(versions[0]).getKey(ref),
-                true);
-
-        LOGGER.debug("Original is:\n {}", xmlOutputter.outputString(data.getOsisFragment()));
-
-        final OsisWrapper interleavedVersions = this.jsi.getInterleavedVersions(versions, ref,
-                new ArrayList<LookupOption>(), InterlinearMode.COLUMN_COMPARE, "en");
-
-        final SAXBuilder sb = new SAXBuilder();
-        final Document d = sb.build(new StringReader(interleavedVersions.getValue()));
-        LOGGER.debug("\n {}", xmlOutputter.outputString(d));
-    }
-
-    /**
-     * Justs shows XML on the stdout
-     *
-     * @throws BookException      an exceptioon
-     * @throws NoSuchKeyException an exception
-     * @throws IOException        an exception
-     * @throws JDOMException      an exception
-     */
-    @Test
-    public void testSegVariants() throws BookException, NoSuchKeyException, JDOMException, IOException {
-        final XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
-        final String ref = "Mat.9.4";
-        final String version = "WHNU";
-
-        final Book book = Books.installed().getBook(version);
-
-        // do the test
-        final BookData data = new BookData(book, book.getKey(ref));
-
-        LOGGER.info("Original is:\n {}", xmlOutputter.outputString(data.getOsisFragment()));
-
-        final OsisWrapper interleavedVersions = this.jsi.getOsisText(version, ref);
-
-        final SAXBuilder sb = new SAXBuilder();
-        final Document d = sb.build(new StringReader(interleavedVersions.getValue()));
-        final String outputString = xmlOutputter.outputString(d);
-        LOGGER.info(outputString);
-        assertTrue(outputString.contains("ειδως"));
-        assertTrue(outputString.contains("title=\"ιδων"));
-    }
-
-    /**
-     * Justs shows XML on the stdout
-     *
-     * @throws BookException      an exceptioon
-     * @throws NoSuchKeyException an exception
-     * @throws IOException        an exception
-     * @throws JDOMException      an exception
-     */
-    @Test
     public void testLongHeaders() throws BookException, NoSuchKeyException, JDOMException, IOException {
         final String version = "ESV_th";
         final String ref = "Luk 4:27";
@@ -395,17 +335,6 @@ public class JSwordPassageServiceImplTest {
         }
 
         Assert.assertTrue(osisText.contains("Luke 4:27"));
-    }
-
-    /**
-     * Tests a lookup by number
-     */
-    @Test
-    public void testNumberLookup() {
-        assertTrue(this.jsi
-                .getOsisTextByVerseNumbers("FreSegond", "ESV_th", 60000, 60000, new ArrayList<LookupOption>(),
-                        null, null, false).getValue()
-                .contains("Que la gr\u00e2ce du Seigneur J\u00e9sus soit avec tous!"));
     }
 
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/jsword/impl/JSwordPassageServiceImplTest.java
@@ -11,12 +11,13 @@ import org.crosswire.jsword.book.Book;
 import org.crosswire.jsword.book.BookData;
 import org.crosswire.jsword.book.BookException;
 import org.crosswire.jsword.book.Books;
-import org.crosswire.jsword.passage.*;
+import org.crosswire.jsword.passage.Key;
+import org.crosswire.jsword.passage.NoSuchKeyException;
+import org.crosswire.jsword.passage.Verse;
 import org.crosswire.jsword.versification.BibleBook;
 import org.crosswire.jsword.versification.Versification;
 import org.crosswire.jsword.versification.system.Versifications;
 import org.jdom2.Document;
-import org.jdom2.Element;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.output.Format;
@@ -111,101 +112,6 @@ public class JSwordPassageServiceImplTest {
                 new Verse(Versifications.instance().getVersification(Versifications.DEFAULT_V11N),
                         BibleBook.RUTH, 1, 22), 0);
         LOGGER.debug(expandToFullChapter.getName());
-    }
-
-    /**
-     * tests what happens when we select interlinear
-     *
-     * @throws NoSuchKeyException uncaught exceptions
-     * @throws BookException      uncaught exception
-     * @throws IOException        uncaught exception
-     * @throws JDOMException      uncaught exception
-     */
-    @Test
-    public void testInterlinearTransformation() throws NoSuchKeyException, BookException, JDOMException,
-            IOException {
-        final Book currentBook = Books.installed().getBook("OSMHB");
-        final BookData bookData = new BookData(currentBook, currentBook.getKey("Ps.51"));
-        final Element osisFragment = bookData.getOsisFragment();
-
-        final XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
-        LOGGER.trace(xmlOutputter.outputString(osisFragment));
-
-        // do the test
-        final List<LookupOption> options = new ArrayList<LookupOption>();
-        // options.add(INTERLINEAR);
-
-        final String osisText = this.jsi.getOsisText("OSMHB", "Ps.51", options, "ESV_th",
-                InterlinearMode.INTERLINEAR).getValue();
-        final SAXBuilder sb = new SAXBuilder();
-        final Document d = sb.build(new StringReader(osisText));
-
-        LOGGER.trace("\n {}", xmlOutputter.outputString(d));
-        Assert.assertTrue(osisText.contains("span class='interlinear'"));
-
-    }
-
-    /**
-     * tests that the XSLT transformation is handled correctly
-     *
-     * @throws BookException      uncaught exception
-     * @throws NoSuchKeyException uncaught exception
-     * @throws IOException        uncaught exception
-     * @throws JDOMException      uncaught exception
-     */
-    @Test
-    public void testXslTransformation() throws BookException, NoSuchKeyException, JDOMException, IOException {
-        final Book currentBook = Books.installed().getBook("KJV");
-        final BookData bookData = new BookData(currentBook, currentBook.getKey("Romans 1:4"));
-        final Element osisFragment = bookData.getOsisFragment();
-
-        final XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
-        LOGGER.trace(xmlOutputter.outputString(osisFragment));
-
-        // do the test
-        final List<LookupOption> options = new ArrayList<LookupOption>();
-
-        final String osisText = this.jsi.getOsisText("KJV", "Romans 1:4", options, "", InterlinearMode.NONE)
-                .getValue();
-        final SAXBuilder sb = new SAXBuilder();
-        final Document d = sb.build(new StringReader(osisText));
-
-        LOGGER.trace("\n {}", xmlOutputter.outputString(d));
-        Assert.assertTrue(osisText.contains("span"));
-    }
-
-    /**
-     * tests that the XSLT transformation is handled correctly
-     *
-     * @throws BookException      uncaught exception
-     * @throws NoSuchKeyException uncaught exception
-     * @throws IOException        uncaught exception
-     * @throws JDOMException      uncaught exception
-     */
-    @Test
-    public void testComparing() throws BookException, NoSuchKeyException, JDOMException, IOException {
-        final Book currentBook = Books.installed().getBook("ESV_th");
-        final Book secondaryBook = Books.installed().getBook("KJV");
-
-        final String reference = "Psalm.3";
-        final BookData bookData = new BookData(new Book[]{currentBook, secondaryBook},
-                currentBook.getKey(reference), true);
-        final Element osisFragment = bookData.getOsisFragment();
-
-        final XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat());
-        LOGGER.info(xmlOutputter.outputString(osisFragment));
-
-        // do the test
-        final List<LookupOption> options = new ArrayList<LookupOption>();
-
-        final String osisText = this.jsi.getInterleavedVersions(
-                new String[]{currentBook.getInitials(), secondaryBook.getInitials()}, reference, options,
-                InterlinearMode.INTERLEAVED_COMPARE, "en").getValue();
-        final SAXBuilder sb = new SAXBuilder();
-        final Document d = sb.build(new StringReader(osisText));
-
-        LOGGER.info("\n {}", xmlOutputter.outputString(d));
-        Assert.assertTrue(osisText.contains("span"));
     }
 
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImplTest.java
@@ -46,16 +46,6 @@ public class SearchServiceImplTest {
     }
 
     /**
-     * Random tests
-     */
-    @Test
-    public void testMultiVersionSearch() {
-        final List<SearchEntry> results = this.searchServiceUnderTest.search(
-                new SearchQuery("t=elijah", new String[]{"ESV_th", "KJV", "ASV"}, "false", 0, 1, 1, null, "AND")).getResults();
-        assertFalse(results.isEmpty());
-    }
-
-    /**
      * test exact strong match
      */
     @Test

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringConversionUtilsTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/StringConversionUtilsTest.java
@@ -90,9 +90,9 @@ public class StringConversionUtilsTest {
     public void testGetStrongPaddedKey() {
         assertEquals("", getStrongPaddedKey(null));
         assertEquals("", getStrongPaddedKey(""));
-        assertEquals("g", getStrongPaddedKey("G"));
-        assertEquals("h", getStrongPaddedKey("H"));
-        assertEquals("000a", getStrongPaddedKey("A"));
+        assertEquals("G", getStrongPaddedKey("G"));
+        assertEquals("H", getStrongPaddedKey("H"));
+        assertEquals("000A", getStrongPaddedKey("A"));
         assertEquals("G1020", getStrongPaddedKey("strong:G1020"));
         assertEquals("G0001", getStrongPaddedKey("strong:G1"));
         assertEquals("G0012", getStrongPaddedKey("strong:G12"));
@@ -104,8 +104,8 @@ public class StringConversionUtilsTest {
         assertEquals("0123", getStrongPaddedKey("strong:123"));
         assertEquals("1234", getStrongPaddedKey("strong:1234"));
         assertEquals("H1234 H5678",  getStrongPaddedKey("H01234 H5678"));
-        assertEquals("H1234 H5678a", getStrongPaddedKey("H01234 H5678A"));
-        assertEquals("H1234a H5678", getStrongPaddedKey("H01234A H5678"));
+        assertEquals("H1234 H5678A", getStrongPaddedKey("H01234 H5678A"));
+        assertEquals("H1234A H5678", getStrongPaddedKey("H01234A H5678"));
     }
 
     /**

--- a/step-core/src/test/java/com/tyndalehouse/step/core/utils/language/GreekUtilsTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/utils/language/GreekUtilsTest.java
@@ -1,16 +1,9 @@
 package com.tyndalehouse.step.core.utils.language;
 
-import org.crosswire.jsword.book.Book;
-import org.crosswire.jsword.book.BookData;
-import org.crosswire.jsword.book.Books;
-import org.jdom2.Element;
-import org.jdom2.output.Format;
-import org.jdom2.output.XMLOutputter;
 import org.junit.Test;
 
 import static com.tyndalehouse.step.core.utils.language.GreekUtils.unAccent;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * Greek utils tests
@@ -21,32 +14,5 @@ public class GreekUtilsTest {
     public void testUnaccentRegexParses() {
         final String unAccent = unAccent("Some word\u2e00is\u2e02 here\u0308");
         assertEquals("Some wordis here", unAccent);
-
-    }
-
-    /**
-     * Tests that combining characters get removed in comparisons
-     * 
-     * @throws Exception an uncaught exception
-     */
-    @Test
-    public void testDodgyUnicodeGreekCombiningCharacters() throws Exception {
-        final String[] versions = new String[] { "SBLGNT", "TR" };
-        final String ref = "Mar 3:3";
-        final Book currentBook = Books.installed().getBook(versions[0]);
-
-        final Book[] books = new Book[versions.length];
-        for (int ii = 0; ii < versions.length; ii++) {
-            books[ii] = Books.installed().getBook(versions[ii]);
-        }
-
-        final BookData bookData = new BookData(books, currentBook.getKey(ref), false);
-        final Element osisFragment = bookData.getOsisFragment();
-
-        final XMLOutputter xmlOutputter = new XMLOutputter(Format.getRawFormat());
-        final String unAccented = xmlOutputter.outputString(osisFragment);
-        for (int ii = 0; ii < unAccented.length(); ii++) {
-            assertTrue(unAccented.charAt(ii) < 0xe200);
-        }
     }
 }

--- a/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/xsl/impl/InterleavingProviderImplTest.java
@@ -16,31 +16,6 @@ import static org.mockito.Mockito.when;
  * A simple test class to test to the provider
  */
 public class InterleavingProviderImplTest {
-
-    /**
-     * check that comparing adds the right set of versions
-     */
-    @Test
-    public void testInterleavingCompare() {
-        final JSwordVersificationService versification = mock(JSwordVersificationService.class);
-
-        when(versification.getBookFromVersion(anyString())).thenAnswer(new Answer<Book>() {
-
-            @Override
-            public Book answer(final InvocationOnMock invocation) {
-                return Books.installed().getBook((String) invocation.getArguments()[0]);
-            }
-        });
-
-        final InterleavingProviderImpl interleavingProviderImpl = new InterleavingProviderImpl(versification,
-                new String[] { "KJV", "ESV_th", "NETfree", "Byz", "Tisch", "YLT", "ASV", "Montgomery",
-                        "FreCrampon" }, true);
-
-        final String[] expected = new String[] { "KJV", "ESV_th", "KJV", "NETfree", "KJV", "YLT", "KJV", "ASV",
-                "KJV", "Montgomery", };
-        assertEqualVersions(expected, interleavingProviderImpl);
-    }
-
     /**
      * Tests that the main version obliterates the presence of the same version within the list.
      */
@@ -61,8 +36,6 @@ public class InterleavingProviderImplTest {
 
         assertEqualVersions(new String[] { "KJV", "ESV_th", "KJV", "ESV_th"}, interleavingProviderImpl);
     }
-
-
 
     /**
      * check that comparing adds the right set of versions

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/framework/FrontControllerTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/framework/FrontControllerTest.java
@@ -1,7 +1,6 @@
 package com.tyndalehouse.step.rest.framework;
 
 import com.google.inject.Injector;
-import com.tyndalehouse.step.core.exceptions.StepInternalException;
 import com.tyndalehouse.step.core.models.ClientSession;
 import com.tyndalehouse.step.core.service.AppManagerService;
 import com.tyndalehouse.step.core.service.BibleInformationService;
@@ -15,8 +14,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import javax.inject.Provider;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -61,57 +58,9 @@ public class FrontControllerTest {
         final ObjectMapper mockMapper = mock(ObjectMapper.class);
         when(mockMapper.writeValueAsString(any(Object.class))).thenReturn("Test");
         when(this.objectMapper.get()).thenReturn(mockMapper);
-        
+
         this.fcUnderTest = new FrontController(this.guiceInjector, mock(AppManagerService.class), this.errorResolver,
                 this.clientSessionProvider, objectMapper);
-    }
-
-    /**
-     * Tests normal operation of a GET method
-     *
-     * @throws IOException uncaught exception
-     */
-    @Test
-    public void testDoGet() throws Exception {
-        final HttpServletRequest req = mock(HttpServletRequest.class);
-        final HttpServletResponse response = mock(HttpServletResponse.class);
-        final String sampleRequest = "step-web/rest/bible/get/1K2/2K2/";
-
-        when(req.getRequestURI()).thenReturn(sampleRequest);
-        when(req.getServletPath()).thenReturn("step-web/");
-        when(req.getContextPath()).thenReturn("rest/");
-
-        final FrontController fc = spy(this.fcUnderTest);
-
-        final ServletOutputStream mockOutputStream = mock(ServletOutputStream.class);
-
-        doReturn(mockOutputStream).when(response).getOutputStream();
-        final byte[] sampleResponse = new byte[]{1, 2, 3};
-        doReturn(sampleResponse).when(fc).invokeMethodWithStepRequest(any(StepRequest.class));
-
-        // do the test
-        assertEquals(sampleResponse, fc.invokeMethod(req));
-    }
-
-    /**
-     * tests what happens when doGet catches an exception
-     */
-    @Test
-    public void testDoGetHasException() {
-        final HttpServletRequest request = mock(HttpServletRequest.class);
-        final HttpServletResponse response = mock(HttpServletResponse.class);
-        final StepInternalException testException = new StepInternalException("A test exception");
-
-        final FrontController fc = spy(this.fcUnderTest);
-        final StepRequest parsedRequest = new StepRequest("blah", "SomeController", "someMethod",
-                new String[]{"arg1", "arg2"});
-
-        // TODO remove this/
-        doNothing().when(fc).handleError(response, testException, mock(HttpServletRequest.class));
-
-        // do the test
-        fc.doGet(request, response);
-
     }
 
     /**
@@ -177,44 +126,5 @@ public class FrontControllerTest {
         assertArrayEquals(new Class<?>[]{String.class, Integer.class},
                 this.fcUnderTest.getClasses(new Object[]{"hello", Integer.valueOf(1)}));
 
-    }
-
-    /**
-     * If an error was thrown, we should map it and output
-     *
-     * @throws IOException uncaught exception
-     */
-    @Test
-    public void testDoErrorHandlesCorrectly() throws IOException {
-        final HttpServletResponse response = mock(HttpServletResponse.class);
-        // final StepRequest stepRequest = new StepRequest("blah", "controller", "method", null);
-        final ServletOutputStream outputStream = mock(ServletOutputStream.class);
-        final Throwable exception = new Exception();
-        when(response.getOutputStream()).thenReturn(outputStream);
-        when(this.stepRequest.getCacheKey()).thenReturn(new ControllerCacheKey("method", "results"));
-
-        // do test
-        this.fcUnderTest.handleError(response, exception, mock(HttpServletRequest.class));
-
-        // check
-        verify(outputStream).write(any(byte[].class));
-    }
-
-    /**
-     * We check that invoke method calls the correct controller and method with the right arguments
-     */
-    @Test
-    public void testInvokeMethod() throws Exception {
-        final StepRequest sr = new StepRequest("blah", "bible", "getAllFeatures", new String[]{});
-        final BibleController testController = mock(BibleController.class);
-
-        final FrontController fc = spy(this.fcUnderTest);
-        doReturn(testController).when(fc).getController("bible", false);
-
-        // do test
-        fc.invokeMethodWithStepRequest(sr);
-
-        // verify
-        verify(testController).getAllFeatures();
     }
 }

--- a/step-web/src/test/java/com/tyndalehouse/step/rest/framework/StepRequestTest.java
+++ b/step-web/src/test/java/com/tyndalehouse/step/rest/framework/StepRequestTest.java
@@ -2,14 +2,8 @@ package com.tyndalehouse.step.rest.framework;
 
 import org.junit.Test;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests that cache keys are constructed correctly
@@ -47,77 +41,6 @@ public class StepRequestTest {
         for (final String s : TEST_ARGS) {
             assertTrue(resultsKey.contains(s));
         }
-
-    }
-
-    /**
-     * testing simple parsing of arguments
-     */
-    @Test
-    public void testParseArguments() {
-        // index starts at ...........0123456789-123456789-123456
-        final String stepRequest = "step-web/rest/bible/get/1K2/2K2/";
-        final HttpServletRequest req = mock(HttpServletRequest.class);
-
-        when(req.getRequestURI()).thenReturn(stepRequest);
-        when(req.getServletPath()).thenReturn("step-web/");
-        when(req.getContextPath()).thenReturn("rest/");
-
-        // index starts at ...........0123456789-123456789-123456
-        final StepRequest sr = new StepRequest(req, UTF_8_ENCODING);
-        assertEquals(2, sr.getArgs().length);
-        assertEquals("1K2", sr.getArgs()[0]);
-        assertEquals("2K2", sr.getArgs()[1]);
-    }
-
-    /**
-     * tests that parsing of request works if request finishes with a slash
-     */
-    @Test
-    public void testGetArgsFinishingWithSlash() {
-        // index starts at ...........0123456789-123456789-123456
-        final String sampleRequest = "step-web/rest/bible/get/1K2/2K2/";
-        final HttpServletRequest req = mock(HttpServletRequest.class);
-
-        when(req.getRequestURI()).thenReturn(sampleRequest);
-        when(req.getServletPath()).thenReturn("step-web/");
-        when(req.getContextPath()).thenReturn("rest/");
-
-        final StepRequest sr = new StepRequest(req, UTF_8_ENCODING);
-
-        // then
-        assertEquals(2, sr.getArgs().length);
-        assertEquals("1K2", sr.getArgs()[0]);
-        assertEquals("2K2", sr.getArgs()[1]);
-    }
-
-    /**
-     * we check that the path is concatenated with the servlet path
-     * 
-     * @throws ServletException an uncaught exception
-     * @throws InvocationTargetException an uncaught exception
-     * @throws IllegalAccessException an uncaught exception
-     * @throws NoSuchMethodException an uncaught exception
-     */
-    @Test
-    public void testGetPath() throws ServletException, IllegalAccessException, InvocationTargetException,
-            NoSuchMethodException {
-
-        // length is: 1234567890123456789012345
-        final String sampleRequest = "step-web/rest/bible/get/1K2/2K2/";
-        final HttpServletRequest req = mock(HttpServletRequest.class);
-
-        when(req.getRequestURI()).thenReturn(sampleRequest);
-        when(req.getServletPath()).thenReturn("letters");
-        when(req.getContextPath()).thenReturn("more");
-
-        // then
-        final StepRequest sr = new StepRequest(req, "UTF-8");
-        final Method declaredMethod = sr.getClass().getDeclaredMethod("getPathLength",
-                HttpServletRequest.class);
-        declaredMethod.setAccessible(true);
-
-        assertEquals(11, declaredMethod.invoke(sr, req));
     }
 
     /**


### PR DESCRIPTION
## Why

I noticed that on my local machine some modules don't download during the test setup process (the specific issue that caused this was a louis segond not downloading),

I found this failure helpful because it revealed that some tests depend on local state, which means that if a module changed slightly, a test would fail, and not for code-related reasons, resulting in flakey tests,

By the end of removing some of these tests, I got everything to pass on my machine,

I am open to ideas though, if some of these tests are high value, instead of removing them I could rewrite them to create and destroy any state needed for a test within the test code itself, so that each test is isolated from a data perspective!