### PR TITLE
Fix corrupted screenshot that was side effect of the Unicode fix

### DIFF
--- a/step-web/src/main/webapp/js/step.util.js
+++ b/step-web/src/main/webapp/js/step.util.js
@@ -283,7 +283,7 @@ step.util = {
         dataToBeSent.push(startTokenBoundary);
         dataToBeSent.push('Content-Disposition: form-data; name="' + name + '"; filename="' + fn + '"');
         dataToBeSent.push('');
-        dataToBeSent.push(atob(data));
+        dataToBeSent.push(data);    // send the image as is (base64 encoded). The server will decode
         dataToBeSent.push(startTokenBoundary + '--');
         dataToBeSent.push('');
 
@@ -296,7 +296,6 @@ step.util = {
                 }
             }
         };
-        // xhr.sendAsBinary is obsolete and causes Unicode issues
         xhr.send(dataToBeSent.join('\r\n'));
     },
     refreshColumnSize: function (columns) {


### PR DESCRIPTION
The screenshot was decoded from base64 before sending to the server. The XMLHttpRequest.send() finds non ascii data and tries to adjust to Unicode. This fix moves the decoding to the server.