### PR TITLE
apply default font sizes to notes + quickLexicon + sidebar lexicon

### DIFF
--- a/step-web/src/main/webapp/js/step.util.js
+++ b/step-web/src/main/webapp/js/step.util.js
@@ -936,6 +936,8 @@ step.util = {
 					var fontInElements = element.find("." + fontArray[j]);
 					if (fontInElements.length > 0)
 						fontInElements.css("font-size", fontSize);
+					if ((fontArray[j] === "defaultfont") || ($(element).hasClass(fontArray[j])))
+						document.body.style.setProperty("--stepDefaultFontSize", fontSize + "px");
 				}
 			}
 		}
@@ -955,6 +957,7 @@ step.util = {
 
 		var fontArray = ["hbFont", "unicodeFont", "arabicFont", "burmeseFont", "chineseFont", "copticFont", "farsiFont", "khmerFont", "syriacFont"];
 		currentFontSize = step.util.getFontSize(fontName, panelNumber, elements);
+		var newDefaultFontSize = undefined;
 		if (currentFontSize > 0) {
 			for (var i = 0; i < elements.length; i++) {
 				var fontNeedToRestoreSize = {};
@@ -977,6 +980,9 @@ step.util = {
 					}
 					if (fontName === "defaultfont") {
 						$(elements[i]).css("font-size", newFontSize);
+                                                if (typeof panelNumber !== "number") {
+                                                    document.body.style.setProperty("--stepDefaultFontSize", newFontSize + "px");
+                                                }
 						// restore font size of other fonts which are not defaultfont
 						// When the defaultfont size change, the other font size can be affected because 
 						// some font size (e.g. hbFont is 150%) of the default size.

--- a/step-web/src/main/webapp/scss/defaults.scss
+++ b/step-web/src/main/webapp/scss/defaults.scss
@@ -20,8 +20,19 @@ body {
   color: var(--clrText);
 }
 
-body, .dropdown-menu, #quickLexicon h1 {
+body, .dropdown-menu {
   font-size: $defaultFontSize;
+  --stepDefaultFontSize: $defaultFontSize;
+}
+
+#quickLexicon {
+  font-size: var(--stepDefaultFontSize);
+  > div {
+    font-size: 0.8em;
+  }
+  h1 {
+    font-size: 0.8em;
+  }
 }
 
 .dropdown-menu > li > a {

--- a/step-web/src/main/webapp/scss/passage.scss
+++ b/step-web/src/main/webapp/scss/passage.scss
@@ -402,9 +402,13 @@ TD.text {
   front-size: xx-small;
 }
 
+h3.psalmHeading {
+  font-size: 0.8em;
+}
+
 h3.psalmHeading .note {
   font-variant: normal;
-  font-size: x-small;
+  font-size: 0.75em;
 }
 
 .hebrewLanguage {

--- a/step-web/src/main/webapp/scss/quick_lexicon.scss
+++ b/step-web/src/main/webapp/scss/quick_lexicon.scss
@@ -45,7 +45,7 @@
 //    line-height: 18px;
   }
   .mediumDef {
-    font-size: 13px;
+    font-size: 0.8667em;
 //    line-height: 18px;
     max-height: 108px;
     margin-top: 0;
@@ -74,7 +74,7 @@
     display: inline-block;
     clear: left;
 //    margin-top: 5px;
-    font-size: 18px;
+    font-size: 1.2em;
   }
 
   .hbFontSmall {
@@ -83,7 +83,7 @@
   }
 
   .infoTagLine {
-    font-size: x-small;
+    font-size: 0.8em;
     text-align: left;
     display: block;
     font-family: tahoma;

--- a/step-web/src/main/webapp/scss/sidebar_definition.scss
+++ b/step-web/src/main/webapp/scss/sidebar_definition.scss
@@ -3,7 +3,7 @@
 #lexicon {
   color: $text-color;
 
-  font-size: 14px;
+  font-size: var(--stepDefaultFontSize);
   font-family: $font-family-primary;
 
   h1,
@@ -13,17 +13,21 @@
     margin-bottom: 10px;
   }
 
+  > * {
+    font-size: 0.9333em;
+  }
+
   h1 {
     font-size: $chapter-title-size;
     margin-top: 0;
   }
 
   h2 {
-    font-size: 17px;
+    font-size: 1.1333em;
   }
 
   h3 {
-    font-size: 12px;
+    font-size: 0.8em;
     display: inline;
     &:after {
       content: ": ";


### PR DESCRIPTION
This allows the default font size setting to also apply to notes/quickLexicon and sidebar lexicon text.