### PR TITLE
feat: move copy button to panel toolbar on mobile

### DIFF
--- a/step-web/src/main/webapp/js/step_ready.js
+++ b/step-web/src/main/webapp/js/step_ready.js
@@ -600,7 +600,7 @@
 		var ua = navigator.userAgent.toLowerCase();
 		if (ua.indexOf('firefox') > -1) $("#panel-icon").hide(); // Firefox has some issues with this.
         if ((typeof navigator.clipboard !== "object") || (typeof navigator.clipboard.writeText !== "function"))
-            $("#copy-icon").hide();
+            { $("#copy-icon").hide(); $(".panelCopyBtn").hide(); }
 		if ( ((step.appleTouchDevice) && (ua.search(/ cpu os [345678]_/) > -1)) || // older versions of iOS shows a light grey color.  Probably similiar issue as Internet Explorer
 			(false || !!document.documentMode) ) { // Internet Explorer use the wrong css based on the <a> tag, so change it to black
 			$("#panel-icon").css("color", "black");

--- a/step-web/src/main/webapp/start.jsp
+++ b/step-web/src/main/webapp/start.jsp
@@ -271,7 +271,7 @@
                                 <span class="icon-bar"></span>
                                 <span class="icon-bar"></span>
                             </button>
-                            <a data-button-name="copy" data-button-location="navbar" id="copy-icon" style="padding-left:5px" href="javascript:step.util.copyModal();" title="<fmt:message key="copy" />">
+                            <a data-button-name="copy" data-button-location="navbar" id="copy-icon" class="hidden-xs" style="padding-left:5px" href="javascript:step.util.copyModal();" title="<fmt:message key="copy" />">
                                 <i class="glyphicon glyphicon-copy"></i><span class="hidden-xs navbarIconDesc">&nbsp;&nbsp;<fmt:message key="copy" /></span>
                             </a>
                             <span data-button-name="resources" data-button-location="navbar" class="dropdown">
@@ -445,6 +445,11 @@
                                         <i class="glyphicon glyphicon-resize-small" style="display:none"></i>
                                     </a>
                                 </span>
+                                <a class="panelCopyBtn hidden-sm hidden-md hidden-lg" data-button-name="copy" data-button-location="panel"
+                                   href="javascript:step.util.copyModal();"
+                                   title="<fmt:message key="copy" />">
+                                    <i class="glyphicon glyphicon-copy"></i>
+                                </a>
                                 <span class="dropdown settingsDropdown" style="background-color:var(--clrBackground)">
                                         <a class="dropdown-toggle showSettings" data-toggle="dropdown"
                                            title="<fmt:message key="view" />">


### PR DESCRIPTION
On mobile/narrow screens (< 768px), hide the navbar copy icon and show a new copy button in the passage panel toolbar, to the left of the settings cog. On desktop the navbar button remains unchanged.