### PR TITLE
fix(verse_popup): drop margin/padding on .relatedVersesChooser anchors

### DIFF
--- a/step-web/src/main/webapp/scss/verse_popup.scss
+++ b/step-web/src/main/webapp/scss/verse_popup.scss
@@ -67,11 +67,6 @@ div.versePopup.qtip-default.qtip {
     padding-bottom: 10px;
     border-bottom: 1px dotted #ccc;
     color: $text-color;
-
-    a {
-      margin-right: 10px;
-      padding-right: 10px;
-    }
   }
 
 }


### PR DESCRIPTION
The 10px margin-right + 10px padding-right was copy-pasted from .verseVocabLinks where it brackets a CSS border-right divider; the chooser uses a literal "|" character instead, so the same rule just adds dead space and extends the underline 10px past "vocabulary". Removing the nested anchor block lets the popup-wide a { padding: 0px } rule apply.