### PR TITLE
fix(search): honor display mode for semantic related verses

### DIFF
--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
@@ -1165,7 +1165,7 @@ public class SearchServiceImpl implements SearchService {
         if (total == 0) return emptyRelatedVersesResult(sq);
 
         final SearchResult result = this.jswordSearch.getResultsFromTrimmedKeys(
-                sq, new String[]{version}, total, ordered, "");
+                sq, curr.getVersions(), total, ordered, "");
         result.setQuery(sq.getOriginalQuery());
         return result;
     }


### PR DESCRIPTION
Pass the user's full version stack to getResultsFromTrimmedKeys so COLUMN / INTERLINEAR / INTERLEAVED / COMPARE modes survive past getBestInterlinearMode's empty-extras short-circuit. Inlined NRSV-rank ordering via DefaultKeyList is preserved.