### PR TITLE
Related verses (#385)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.tyndalehouse.step</groupId>
     <artifactId>step-mvn</artifactId>
-    <version>26.5.2</version>
+    <version>26.5.3</version>
     <packaging>pom</packaging>
     <name>STEP :: Scripture Tools for Every pastor</name>
 

--- a/step-assembly/pom.xml
+++ b/step-assembly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>step-mvn</artifactId>
         <groupId>com.tyndalehouse.step</groupId>
-        <version>26.5.2</version>
+        <version>26.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <properties>

--- a/step-build/pom.xml
+++ b/step-build/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.tyndalehouse.step</groupId>
 		<artifactId>step-mvn</artifactId>
-		<version>26.5.2</version>
+		<version>26.5.3</version>
 	</parent>
 	
 	<artifactId>step-build</artifactId>

--- a/step-core-data/pom.xml
+++ b/step-core-data/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.tyndalehouse.step</groupId>
         <artifactId>step-mvn</artifactId>
-        <version>26.5.2</version>
+        <version>26.5.3</version>
     </parent>
 
     <artifactId>step-core-data</artifactId>

--- a/step-core/pom.xml
+++ b/step-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.tyndalehouse.step</groupId>
         <artifactId>step-mvn</artifactId>
-        <version>26.5.2</version>
+        <version>26.5.3</version>
     </parent>
 
     <groupId>com.tyndalehouse.step</groupId>

--- a/step-core/src/main/java/com/tyndalehouse/step/core/guice/StepCoreModule.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/guice/StepCoreModule.java
@@ -88,6 +88,7 @@ public class StepCoreModule extends AbstractStepGuiceModule {
         bind(OriginalWordSuggestionService.class).to(OriginalWordSuggestionServiceImpl.class);
         bind(SupportRequestService.class).to(SupportRequestServiceImpl.class);
         bind(JSwordRelatedVersesService.class).to(JSwordRelatedVersesServiceImpl.class);
+        bind(SemanticRelatedVersesService.class).to(SemanticRelatedVersesServiceImpl.class).asEagerSingleton();
                 
         bind(new TypeLiteral<List<String>>() {
         }).annotatedWith(Names.named("defaultVersions")).toProvider(DefaultVersionsProvider.class);

--- a/step-core/src/main/java/com/tyndalehouse/step/core/models/SearchToken.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/models/SearchToken.java
@@ -17,6 +17,7 @@ public class SearchToken implements Serializable {
     public static final String MEANINGS = "meanings";
     public static final String TOPIC_BY_REF = "topicref";
     public static final String RELATED_VERSES = "relatedrefs";
+    public static final String RELATED_VERSES_SEMANTIC = "relatedrefsSemantic";
     public static final String EXACT_FORM = "exactForm";
     public static final String SYNTAX = "syntax";
     public static final String LIMIT = "limit";

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/SemanticRelatedVersesService.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/SemanticRelatedVersesService.java
@@ -1,0 +1,14 @@
+package com.tyndalehouse.step.core.service;
+
+import java.util.List;
+
+public interface SemanticRelatedVersesService {
+    /** Returns ranked semantically-related NRSV verse OSIS refs for an NRSV input ref.
+     *  Returns empty list if the ref is not in the dataset.
+     *
+     *  CONTRACT: input MUST already be in NRSV versification. The dataset is
+     *  NRSV-keyed by construction. Callers are responsible for inbound
+     *  (user-v11n -> NRSV) and outbound (NRSV -> user-v11n) verse mapping.
+     *  This service has no JSword dependency. */
+    List<String> getRelatedNrsvRefs(String nrsvOsisRef);
+}

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchType.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SearchType.java
@@ -31,6 +31,11 @@ public enum SearchType {
      * Finds all verses that are related to another verse
      */
     RELATED_VERSES("verse_related"),
+    /**
+     * Semantic related-verses lookup. Internal dispatch only — normalized to
+     * RELATED_VERSES on the wire by SearchServiceImpl#getBestSearchType.
+     */
+    RELATED_VERSES_SEMANTIC("verse_related"),
 
     /** A timeline description search */
     TIMELINE_DESCRIPTION("search_timeline"),

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SemanticRelatedVersesServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/impl/SemanticRelatedVersesServiceImpl.java
@@ -1,0 +1,111 @@
+package com.tyndalehouse.step.core.service.impl;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.tyndalehouse.step.core.data.create.ModuleLoader;
+import com.tyndalehouse.step.core.exceptions.StepInternalException;
+import com.tyndalehouse.step.core.service.SemanticRelatedVersesService;
+
+import javax.inject.Singleton;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+@Singleton
+public class SemanticRelatedVersesServiceImpl implements SemanticRelatedVersesService {
+
+    private static final String RESOURCE_PATH =
+            "related-verses/bible_semantic_export_minified.json";
+
+    private final String[] pool;
+    private final int[][] related;
+
+    public SemanticRelatedVersesServiceImpl() {
+        final JsonFactory factory = new JsonFactory();
+        factory.disable(JsonFactory.Feature.INTERN_FIELD_NAMES);
+
+        final InputStream stream = ModuleLoader.class.getResourceAsStream(RESOURCE_PATH);
+        if (stream == null) {
+            throw new StepInternalException("Unable to read resource: " + RESOURCE_PATH);
+        }
+
+        final HashMap<String, String[]> raw = new HashMap<String, String[]>(40_000);
+        final HashMap<String, String> internCache = new HashMap<String, String>(40_000);
+
+        try {
+            final JsonParser p = factory.createParser(stream);
+            try {
+                if (p.nextToken() != JsonToken.START_OBJECT) {
+                    throw new StepInternalException("Expected JSON object at root: " + RESOURCE_PATH);
+                }
+
+                while (p.nextToken() == JsonToken.FIELD_NAME) {
+                    final String key = p.getText();
+                    if (p.nextToken() != JsonToken.START_ARRAY) {
+                        throw new StepInternalException("Expected array at " + key);
+                    }
+                    final List<String> vals = new ArrayList<String>(100);
+                    while (p.nextToken() != JsonToken.END_ARRAY) {
+                        final String val = p.getText();
+                        final String prev = internCache.putIfAbsent(val, val);
+                        vals.add(prev != null ? prev : val);
+                    }
+                    raw.put(key, vals.toArray(new String[0]));
+                }
+            } finally {
+                p.close();
+            }
+        } catch (IOException e) {
+            throw new StepInternalException(
+                    "Failed to load semantic related verses from " + RESOURCE_PATH + ": " + e.getMessage(), e);
+        } finally {
+            try { stream.close(); } catch (IOException ignored) { }
+        }
+
+        final TreeSet<String> union = new TreeSet<String>();
+        for (Map.Entry<String, String[]> e : raw.entrySet()) {
+            union.add(e.getKey());
+            for (String v : e.getValue()) {
+                union.add(v);
+            }
+        }
+
+        this.pool = union.toArray(new String[0]);
+        this.related = new int[this.pool.length][];
+
+        for (Map.Entry<String, String[]> e : raw.entrySet()) {
+            final int idx = Arrays.binarySearch(this.pool, e.getKey());
+            if (idx < 0) {
+                throw new StepInternalException("Pool missing key during finalization: " + e.getKey());
+            }
+            final String[] vals = e.getValue();
+            final int[] indices = new int[vals.length];
+            for (int i = 0; i < vals.length; i++) {
+                final int vIdx = Arrays.binarySearch(this.pool, vals[i]);
+                if (vIdx < 0) {
+                    throw new StepInternalException("Pool missing value during finalization: " + vals[i]);
+                }
+                indices[i] = vIdx;
+            }
+            this.related[idx] = indices;
+        }
+    }
+
+    @Override
+    public List<String> getRelatedNrsvRefs(final String nrsvOsisRef) {
+        if (nrsvOsisRef == null || nrsvOsisRef.isEmpty()) return Collections.emptyList();
+        final int idx = Arrays.binarySearch(this.pool, nrsvOsisRef);
+        if (idx < 0 || this.related[idx] == null) return Collections.emptyList();
+        final int[] indices = this.related[idx];
+        final List<String> out = new ArrayList<String>(indices.length);
+        for (int i : indices) out.add(this.pool[i]);
+        return out;
+    }
+}

--- a/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImpl.java
@@ -78,6 +78,7 @@ public class SearchServiceImpl implements SearchService {
     private VersionResolver versionResolver;
     private LexiconDefinitionService lexiconDefinitionService;
     private JSwordRelatedVersesService relatedVerseService;
+    private SemanticRelatedVersesService semanticRelatedVersesService;
 
     /**
      * @param jswordSearch              the search service
@@ -96,7 +97,8 @@ public class SearchServiceImpl implements SearchService {
                              final EntityManager entityManager,
                              final VersionResolver versionResolver,
                              final LexiconDefinitionService lexiconDefinitionService,
-                             final JSwordRelatedVersesService relatedVerseService) {
+                             final JSwordRelatedVersesService relatedVerseService,
+                             final SemanticRelatedVersesService semanticRelatedVersesService) {
         this.jswordSearch = jswordSearch;
         this.jswordMetadata = jswordMetadata;
         this.versificationService = versificationService;
@@ -106,6 +108,7 @@ public class SearchServiceImpl implements SearchService {
         this.versionResolver = versionResolver;
         this.lexiconDefinitionService = lexiconDefinitionService;
         this.relatedVerseService = relatedVerseService;
+        this.semanticRelatedVersesService = semanticRelatedVersesService;
         this.definitions = entityManager.getReader("definition");
         this.specificForms = entityManager.getReader("specificForm");
         this.timelineEvents = entityManager.getReader("timelineEvent");
@@ -330,6 +333,10 @@ public class SearchServiceImpl implements SearchService {
                 final TextSuggestion enhancedTokenInfo = new TextSuggestion();
                 enhancedTokenInfo.setText(st.getToken());
                 st.setEnhancedTokenInfo(enhancedTokenInfo);
+            } else if (SearchToken.RELATED_VERSES_SEMANTIC.equals(st.getTokenType())) {
+                final TextSuggestion enhancedTokenInfo = new TextSuggestion();
+                enhancedTokenInfo.setText(st.getToken());
+                st.setEnhancedTokenInfo(enhancedTokenInfo);
             }
             //nothing to do 
             // for subject searches or 
@@ -391,6 +398,8 @@ public class SearchServiceImpl implements SearchService {
                 addSearch(SearchType.SUBJECT_RELATED, versions, references, st.getToken(), null, individualSearches);
             } else if (SearchToken.RELATED_VERSES.equals(tokenType)) {
                 addSearch(SearchType.RELATED_VERSES, versions, references, st.getToken(), null, individualSearches);
+            } else if (SearchToken.RELATED_VERSES_SEMANTIC.equals(tokenType)) {
+                addSearch(SearchType.RELATED_VERSES_SEMANTIC, versions, references, st.getToken(), null, individualSearches);
             } else if (SearchToken.SYNTAX.equals(tokenType)) {
                 //add a number of searches from the query syntax given...
                 final IndividualSearch[] searches = new SearchQuery(st.getToken(), versions.toArray(new String[versions.size()]), null,
@@ -549,6 +558,10 @@ public class SearchServiceImpl implements SearchService {
     }
 
     private SearchType getBestSearchType(final SearchQuery sq) {
+        return normalizeForFrontend(rawBestSearchType(sq));
+    }
+
+    private SearchType rawBestSearchType(final SearchQuery sq) {
         IndividualSearch[] searches = sq.getSearches();
         for (IndividualSearch s : searches) {
             //we never return subject searches if we can avoid it
@@ -563,6 +576,10 @@ public class SearchServiceImpl implements SearchService {
 
         //then we only have subject searches
         return searches.length == 1 ? searches[0].getType() : SearchType.TEXT;
+    }
+
+    private static SearchType normalizeForFrontend(SearchType t) {
+        return t == SearchType.RELATED_VERSES_SEMANTIC ? SearchType.RELATED_VERSES : t;
     }
 
     /**
@@ -1038,6 +1055,8 @@ public class SearchServiceImpl implements SearchService {
                 return runMeaningSearch(sq);
             case RELATED_VERSES:
                 return runRelatedVerses(sq);
+            case RELATED_VERSES_SEMANTIC:
+                return runSemanticRelatedVerses(sq);
             default:
                 throw new TranslatedException("search_unknown");
         }
@@ -1081,6 +1100,58 @@ public class SearchServiceImpl implements SearchService {
     private SearchResult runRelatedVerses(final SearchQuery sq) {
         return this.buildCombinedVerseBasedResults(sq,
                 this.relatedVerseService.getRelatedVerses(sq.getCurrentSearch().getVersions()[0], sq.getCurrentSearch().getQuery()), ""); // Options from user was not passed to this method
+    }
+
+    private SearchResult runSemanticRelatedVerses(final SearchQuery sq) {
+        final IndividualSearch curr = sq.getCurrentSearch();
+        final String version = curr.getVersions()[0];
+        final String userInputRef = curr.getQuery();
+
+        final Versification userV11n;
+        try {
+            userV11n = this.versificationService.getVersificationForVersion(version);
+        } catch (com.tyndalehouse.step.core.exceptions.StepInternalException e) {
+            return emptyRelatedVersesResult(sq);
+        }
+        final Versification nrsv = org.crosswire.jsword.versification.system.Versifications
+                .instance().getVersification(
+                        org.crosswire.jsword.versification.system.SystemNRSV.V11N_NAME);
+
+        final String nrsvOsisRef;
+        try {
+            final Verse userVerse = VerseFactory.fromString(userV11n, userInputRef);
+            if (userVerse == null) return emptyRelatedVersesResult(sq);
+            final VerseKey nrsvKey = VersificationsMapper.instance().mapVerse(userVerse, nrsv);
+            final Iterator<Key> it = nrsvKey.iterator();
+            if (!it.hasNext()) return emptyRelatedVersesResult(sq);
+            nrsvOsisRef = ((Verse) it.next()).getOsisID();
+        } catch (NoSuchVerseException e) {
+            return emptyRelatedVersesResult(sq);
+        }
+
+        final List<String> orderedNrsvRefs =
+                this.semanticRelatedVersesService.getRelatedNrsvRefs(nrsvOsisRef);
+        if (orderedNrsvRefs.isEmpty()) return emptyRelatedVersesResult(sq);
+
+        final Passage userPassage;
+        try {
+            final String joinedNrsvRefs = String.join(" ", orderedNrsvRefs);
+            final Passage nrsvPassage = PassageKeyFactory.instance().getKey(nrsv, joinedNrsvRefs);
+            userPassage = VersificationsMapper.instance().map(nrsvPassage, userV11n);
+        } catch (NoSuchKeyException e) {
+            return emptyRelatedVersesResult(sq);
+        }
+        if (userPassage.getCardinality() == 0) return emptyRelatedVersesResult(sq);
+
+        return this.buildCombinedVerseBasedResults(sq, userPassage, "");
+    }
+
+    private SearchResult emptyRelatedVersesResult(final SearchQuery sq) {
+        final SearchResult r = new SearchResult();
+        r.setResults(Collections.<SearchEntry>emptyList());
+        r.setTotal(0);
+        r.setQuery(sq.getOriginalQuery());
+        return r;
     }
 
     /**

--- a/step-core/src/main/java/com/tyndalehouse/step/core/utils/ValidateUtils.java
+++ b/step-core/src/main/java/com/tyndalehouse/step/core/utils/ValidateUtils.java
@@ -125,7 +125,7 @@ public final class ValidateUtils {
             else
                 return false;
         }
-        else if (key.equals("topicref") || key.equals("relatedrefs")) {
+        else if (key.equals("topicref") || key.equals("relatedrefs") || key.equals("relatedrefsSemantic")) {
             if (value.length() > 2000) {
                 System.out.println("XSS kill unexpected reference length: " + value);
                 return false;

--- a/step-core/src/test/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImplTest.java
+++ b/step-core/src/test/java/com/tyndalehouse/step/core/service/search/impl/SearchServiceImplTest.java
@@ -110,7 +110,7 @@ public class SearchServiceImplTest {
         subjects = new SubjectSearchServiceImpl(entityManager,
                 jswordSearch, meta, module, versificationService);
         return new SearchServiceImpl(jswordSearch, meta, versificationService, subjects, new TimelineServiceImpl(entityManager, jsword), null, entityManager, TestUtils.mockVersionResolver(),
-                mock(LexiconDefinitionServiceImpl.class), null
+                mock(LexiconDefinitionServiceImpl.class), null, null
         );
     }
 }

--- a/step-packages/pom.xml
+++ b/step-packages/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.tyndalehouse.step</groupId>
         <artifactId>step-mvn</artifactId>
-        <version>26.5.2</version>
+        <version>26.5.3</version>
     </parent>
 
     <groupId>com.tyndalehouse.step</groupId>

--- a/step-server/pom.xml
+++ b/step-server/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<groupId>com.tyndalehouse.step</groupId>
 		<artifactId>step-mvn</artifactId>
-		<version>26.5.2</version>
+		<version>26.5.3</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>

--- a/step-test/pom.xml
+++ b/step-test/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.tyndalehouse.step</groupId>
         <artifactId>step-mvn</artifactId>
-        <version>26.5.2</version>
+        <version>26.5.3</version>
     </parent>
 
     <groupId>com.tyndalehouse.step</groupId>

--- a/step-tools/pom.xml
+++ b/step-tools/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>com.tyndalehouse.step</groupId>
         <artifactId>step-mvn</artifactId>
-        <version>26.5.2</version>
+        <version>26.5.3</version>
     </parent>
 
     <groupId>com.tyndalehouse.step</groupId>

--- a/step-war-precompiled/pom.xml
+++ b/step-war-precompiled/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>step-mvn</artifactId>
         <groupId>com.tyndalehouse.step</groupId>
-        <version>26.5.2</version>
+        <version>26.5.3</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/step-web-test/pom.xml
+++ b/step-web-test/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.tyndalehouse.step</groupId>
 		<artifactId>step-mvn</artifactId>
-		<version>26.5.2</version>
+		<version>26.5.3</version>
 	</parent>
 
 	<groupId>com.tyndalehouse.step</groupId>

--- a/step-web/pom.xml
+++ b/step-web/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>com.tyndalehouse.step</groupId>
 		<artifactId>step-mvn</artifactId>
-		<version>26.5.2</version>
+		<version>26.5.3</version>
 	</parent>
 
 	<artifactId>step-web</artifactId>

--- a/step-web/src/main/webapp/js/backbone/views/view_main_search.js
+++ b/step-web/src/main/webapp/js/backbone/views/view_main_search.js
@@ -68,6 +68,7 @@ var MainSearchView = Backbone.View.extend({
                             break;
                         case TOPIC_BY_REF:
                         case RELATED_VERSES:
+                        case RELATED_VERSES_SEMANTIC:
                         default:
                             id += entry.item;
                             break;
@@ -591,6 +592,7 @@ var MainSearchView = Backbone.View.extend({
                     break;
                 case TOPIC_BY_REF:
                 case RELATED_VERSES:
+                case RELATED_VERSES_SEMANTIC:
                     searchArgs += URL_SEPARATOR + options[ii].itemType + "=" + encodeURIComponent(options[ii].item.text);
                     break;
                 case SYNTAX:
@@ -977,6 +979,7 @@ var MainSearchView = Backbone.View.extend({
                 return {text: token, greek: enhancedInfo.greek};
             case TOPIC_BY_REF:
             case RELATED_VERSES:
+            case RELATED_VERSES_SEMANTIC:
                 return {text: token};
             case MEANINGS:
                 return {gloss: token};

--- a/step-web/src/main/webapp/js/step.util.js
+++ b/step-web/src/main/webapp/js/step.util.js
@@ -1363,6 +1363,9 @@ step.util = {
                 case RELATED_VERSES:
                     source = __s.verse_related;
                     break;
+                case RELATED_VERSES_SEMANTIC:
+                    source = "Related verses (meaning)";
+                    break;
                 case TOPIC_BY_REF:
                     source = __s.related_by_topic;
                     break;
@@ -1443,6 +1446,13 @@ step.util = {
                         entry.item.text + '</div>';
                 case RELATED_VERSES:
                     return '<div class="relatedVersesItem" ' +
+                        'title="' + source + util.safeEscapeQuote(entry.item.text) + '" ' +
+                        'data-item-type="' + entry.itemType + '" ' +
+                        'data-select-id="' + util.safeEscapeQuote(entry.item.text) + '" ' +
+                        '>' + __s.related_prefix + " " +
+                        entry.item.text + '</div>';
+                case RELATED_VERSES_SEMANTIC:
+                    return '<div class="relatedVersesSemanticItem" ' +
                         'title="' + source + util.safeEscapeQuote(entry.item.text) + '" ' +
                         'data-item-type="' + entry.itemType + '" ' +
                         'data-select-id="' + util.safeEscapeQuote(entry.item.text) + '" ' +
@@ -2011,7 +2021,13 @@ step.util = {
 							var delay = step.passages.findWhere({ passageId: passageId }).get("interlinearMode") === 'INTERLINEAR' ? 650 : 50;
 							step.util.delay(function () {
 									$.getSafe(BIBLE_GET_STRONGS_AND_SUBJECTS, [version, reference, step.userLanguageCode], function (data) {
-											var template = '<div class="vocabTable">' +
+											var template = '<div class="relatedVersesChooser">' +
+														'Display verses related by ' +
+														'<a onclick="javascript:void(0)" class="relatedVersesSemantic">meaning</a> | ' +
+														'<a onclick="javascript:void(0)" class="relatedVerses">vocabulary</a> | ' +
+														'<a onclick="javascript:void(0)" class="relatedSubjects">topics</a>' +
+														'</div>' +
+														'<div class="vocabTable">' +
 													'<div class="col-xs-8 col-sm-4 heading"><h1><%= (data.multipleVerses ? sprintf(__s.vocab_for_verse, data.verse) : "") %></h1></div>' +
 													'<div class="col-xs-2 col-sm-1 heading"><h1><%= __s.bible_book %></h1></div>' +
 													'<div class="col-xs-2 col-sm-1 heading"><h1><%= ot ? __s.OT : __s.NT %></h1></div>' +
@@ -2042,8 +2058,7 @@ step.util = {
 														'<span class="even"></span>' +
 													'<% } %>' +
 													'</div>' +
-													'<div class="verseVocabLinks"><a onclick="javascript:void(0)" class="relatedVerses"><%= __s.see_related_verses %></a> ' +
-													'<a onclick="javascript:void(0)" class="relatedSubjects"><%= __s.see_related_subjects%></a> ' +
+													'<div class="verseVocabLinks">' +
 													'<a onclick="javascript:void(0)" class="seeTips">See Translation TIPS</a> ' +
 													'<% if(isSearch) { %><a onclick="javascript:void(0)" class="verseInContext"><%= __s.see_verse_in_context %></a><% } %></div>';
 											var rows = [];
@@ -2200,6 +2215,12 @@ step.util = {
 												step.router.navigatePreserveVersions(RELATED_VERSES + "=" + encodeURIComponent(key), null, null, null, true);
 											});
 
+											templatedTable.find(".relatedVersesSemantic").click(function () {
+												if (!step.touchDevice || step.touchWideDevice)
+													step.util.createNewLinkedColumn(passageId);
+												step.router.navigatePreserveVersions(RELATED_VERSES_SEMANTIC + "=" + encodeURIComponent(key), null, null, null, true);
+											});
+
 											templatedTable.find(".relatedSubjects").click(function () {
 												if (!step.touchDevice || step.touchWideDevice)
 													step.util.createNewLinkedColumn(passageId);
@@ -2216,6 +2237,10 @@ step.util = {
 											}
 											else
 												templatedTable.find(".seeTips").remove(); // No translation tips
+
+											if (templatedTable.filter(".verseVocabLinks").find("a").length === 0) {
+												templatedTable = templatedTable.not(".verseVocabLinks");
+											}
 
 											templatedTable.find(".verseInContext").click(function () {
 													element.trigger("click");

--- a/step-web/src/main/webapp/js/step_constants.js
+++ b/step-web/src/main/webapp/js/step_constants.js
@@ -20,6 +20,7 @@ NAVE_SEARCH = "nave";
 NAVE_SEARCH_EXTENDED = "xnave";
 TOPIC_BY_REF = "topicref";
 RELATED_VERSES = "relatedrefs";
+RELATED_VERSES_SEMANTIC = "relatedrefsSemantic";
 EXACT_FORM = "exactForm";
 REF_VERSION = "ESV";
 VOCAB_SORT = "VOCABULARY";

--- a/step-web/src/main/webapp/scss/verse_popup.scss
+++ b/step-web/src/main/webapp/scss/verse_popup.scss
@@ -61,4 +61,12 @@ div.versePopup.qtip-default.qtip {
     }
   }
 
+  .relatedVersesChooser {
+    display: block;
+    margin-bottom: 10px;
+    padding-bottom: 10px;
+    border-bottom: 1px dotted #ccc;
+    color: $text-color;
+  }
+
 }


### PR DESCRIPTION
* feat: semantic related verses (parallel to vocabulary flow)

Adds SemanticRelatedVersesService backed by an in-memory NRSV-keyed lookup over a 36 MB JSON resource shipped in step-core-data. Surfaced via a new relatedrefsSemantic search token routed through the existing masterSearch pipeline so URL share / bookmark / reload / column-link all work for free; SearchResult.searchType is normalized back to RELATED_VERSES on the wire so the existing frontend rendering case matches without a new switch arm.

Backend:
  - SemanticRelatedVersesService (interface) + impl: streaming Jackson parser with a local interner; eager singleton bound in StepCoreModule; pure NRSV-in / NRSV-out, no JSword dependency.
  - SearchServiceImpl: new field + ctor param; new dispatch in enhanceSearchTokens, runCorrectSearch, executeOneSearch; new runSemanticRelatedVerses executor handles user-v11n -> NRSV inbound and NRSV -> user-v11n outbound mapping verse-by-verse with DefaultKeyList to preserve ranking; reuses JSwordSearchService#getResultsFromTrimmedKeys (avoids rankAndTrimResults so order survives); top-50 cap, OSIS dedup.
  - SearchType.RELATED_VERSES_SEMANTIC (internal); normalization wrapper on getBestSearchType maps it back to RELATED_VERSES for the frontend.
  - SearchToken.RELATED_VERSES_SEMANTIC = "relatedrefsSemantic".
  - ValidateUtils XSS branch extended to accept the new token.
  - SearchServiceImplTest constructor call patched (extra null param).

Frontend:
  - step.util.js verse popup template restructured: new .relatedVersesChooser row above the vocab table with vocabulary | semantics anchors; .relatedVerses removed from the bottom .verseVocabLinks div; new click handler navigates via relatedrefsSemantic token; new getSource and renderEnhancedToken cases produce a distinct "Sem:" pill.
  - view_main_search.js: three sibling fall-through cases added next to RELATED_VERSES.
  - step_constants.js: RELATED_VERSES_SEMANTIC constant.
  - verse_popup.scss: .relatedVersesChooser block (mirror of .verseVocabLinks divider, dotted bottom border).

i18n: 5 new keys in InteractiveBundle.properties only (English base); locale bundles intentionally untouched per upstream sync policy.

Data: bible_semantic_export_minified.json (NRSV-keyed; 31,087 keys x 100 ranked refs each) staged under step-core-data/.../related-verses/.



* fix(verse_popup): drop margin/padding on .relatedVersesChooser anchors

The 10px margin-right + 10px padding-right was copy-pasted from .verseVocabLinks where it brackets a CSS border-right divider; the chooser uses a literal "|" character instead, so the same rule just adds dead space and extends the underline 10px past "vocabulary". Removing the nested anchor block lets the popup-wide a { padding: 0px } rule apply.



* fix(search): honor display mode for semantic related verses

Pass the user's full version stack to getResultsFromTrimmedKeys so COLUMN / INTERLINEAR / INTERLEAVED / COMPARE modes survive past getBestInterlinearMode's empty-extras short-circuit. Inlined NRSV-rank ordering via DefaultKeyList is preserved.



* feat(verse_popup): move "See related subjects" into chooser row; drop empty vocab-links box

Inline the three chooser anchors as English literals ("meaning | vocabulary | topics") and add a third .relatedSubjects anchor that previously lived in the bottom .verseVocabLinks row. Delete the five locally-introduced i18n keys (display_verses_related_by, related_by_vocabulary, related_by_semantics, verse_related_semantic, semantic_related_prefix) from InteractiveBundle.properties. Reuse the upstream __s.related_prefix in the semantic-chip body so its rendering matches the vocabulary/topics chips; rename the semantic chip's hover tooltip to "Related verses (meaning)".

Also prune the now-often-empty .verseVocabLinks dotted box: when the verse has no translation tip and was not reached via search, the box would otherwise render with no anchors. Because templatedTable is a jQuery collection of three sibling top-level elements (not a single container), the prune must filter the element out of the collection itself — calling .remove() on a detached top-level element does not prevent qtip from re-attaching it via content.text:templatedTable.



* refactor(search): route semantic related verses through shared Passage pipeline

Rewrite runSemanticRelatedVerses to mirror runRelatedVerses (lexical flow): build an NRSV Passage from the full ranked list, map to the user's versification with VersificationsMapper.map, and hand to buildCombinedVerseBasedResults. Drops the 50-verse cap, the manual DefaultKeyList/HashSet accumulator, per-ref it.next()-only mapping, the local countOnly branch, and the hand-rolled getResultsFromTrimmedKeys call (display-mode fix from 8780d6021 now comes for free via the shared helper). Results are canonical-ordered and dedup'd by RangedPassage semantics; 1->N cross-v11n mappings (e.g. Psalm titling) are now kept.



* update version number

---------