### PR TITLE
Show the selected book name in the chapter/verse selection modal

### DIFF
--- a/step-web/src/main/webapp/js/passage_selection.js
+++ b/step-web/src/main/webapp/js/passage_selection.js
@@ -6,6 +6,7 @@ step.passageSelect = {
 	modalMode: 'book',
 	lastOsisID: '',
 	lastNumOfChapters: '',
+	bookDisplayNames: {},
 	arrayOfTyplicalBooksChapters: [],
 	osisChapterJsword: [ // Array of OSIS id, number of chapters in the book and the JSword name (if it is different from OSIS id
 		["Gen", 50, [31,25,24,26,32,22,24,22,29,32,32,20,18,24,21,16,27,33,38,18,34,24,20,67,34,35,46,22,35,43,55,32,20,31,29,43,36,30,23,23,57,38,34,34,28,34,31,22,33,26]],
@@ -82,6 +83,7 @@ step.passageSelect = {
 		this.modalMode = 'book';
 		this.lastOsisID = '';
 		this.lastNumOfChapters = '';
+		this.bookDisplayNames = {};
 		this.arrayOfTyplicalBooksChapters = JSON.parse(__s.list_of_bibles_books);
 		step.util.closeModal('searchSelectionModal');
 		var hideAppend = false;
@@ -269,6 +271,7 @@ step.passageSelect = {
 				longNameToDisplay = data[i].suggestion.fullName;
 				shortNameToDisplay = (this.userLang.toLowerCase().indexOf("en") == 0) ? currentOsisID : data[i].suggestion.shortName.replace(/ /g, "").substr(0, 6);
 			}
+			this.bookDisplayNames[currentOsisID] = longNameToDisplay;
 			var newTestament = (nt.indexOf(currentOsisID) > -1);
 			if (!newTestament) oldTestament = (ot.indexOf(currentOsisID) > -1);
 			if ((newTestament) && (notSeenNT)) {
@@ -530,6 +533,7 @@ step.passageSelect = {
             $.ajaxSetup({async: true});
         }
         
+		var bookNameToDisplay = this.bookDisplayNames[bookOsisID.split('.')[0]] || '';
 		var html = '<div class="header">' +
             '<h4>' + headerMsg + '</h4>';
         if ((isChapter) && 
@@ -544,6 +548,7 @@ step.passageSelect = {
 					'</button>';
         html +=
             '</div>' +
+			((bookNameToDisplay) ? '<span id="selectedBookName" class="stepFgBg" style="font-size:18px"><b>' + bookNameToDisplay + '</b></span>' : '') +
 			'<div style="overflow-y:auto">' +
 			'<table>' +
 			'<colgroup>';
@@ -617,9 +622,10 @@ step.passageSelect = {
 	},
 
 	goBackToPreviousPage: function() {
-		if (this.modalMode === 'verse') {
-			this._buildChptrVrsTbl(null, this.lastOsisID, this.lastNumOfChapters, true);
-			this.modalMode = "chapter";
+		if ((this.modalMode === 'verse') && (this.lastOsisID !== '')) {
+			// _buildChptrVrsTbl sets modalMode itself: 'chapter' normally, 'verse'
+			// when a single-chapter book's auto-jump lands back on the verse grid.
+			this._buildChptrVrsTbl(null, this.lastOsisID, this.lastNumOfChapters, true, this.version, this.userLang);
 		}
 		else {
 			$('#bookchaptermodalbody').empty();


### PR DESCRIPTION
At the chapter and verse stages, #passageSelectionModal now displays the book the user picked at the first stage, directly under the "Please select a chapter/verse" header, styled like the existing OT/NT section headers.

The localized names are captured while the book table is built (both the local-table and suggestion-service paths), keyed by OSIS id on step.passageSelect.bookDisplayNames, and emitted only into element content — never into a javascript: href or an attribute — so names containing apostrophes (e.g. Danish) need no escaping. When no name is known the header renders alone, as before.

Also fixes a pre-existing crash: the back button from the verse stage called _buildChptrVrsTbl without version/userLang, so the Summary-button conditional threw a TypeError before the chapter grid could render (the first click appeared dead and the second skipped to the book list). The call now passes this.version/this.userLang; a guard falls back to the book list when no chapter context was recorded (suggestion-path single-chapter books record none); and modalMode is left to _buildChptrVrsTbl, which already sets it correctly on every render — including the single-chapter case where backing out re-runs the chapter auto-jump and lands back on the verse grid. After the fix, back-navigation returns with Summary off (summaryMode is deliberately not persisted).

Note: on narrow Chinese displays a grid cell can show a truncated book name while the subtitle shows the full name — intentional, matching the cell's existing title attribute.


Claude-Session: https://claude.ai/code/session_019iMHw7cseNqeqHS3hs6oDE