### PR TITLE
Move the selected book name above the chapter/verse header

### DIFF
--- a/step-web/src/main/webapp/js/passage_selection.js
+++ b/step-web/src/main/webapp/js/passage_selection.js
@@ -534,7 +534,8 @@ step.passageSelect = {
         }
         
 		var bookNameToDisplay = this.bookDisplayNames[bookOsisID.split('.')[0]] || '';
-		var html = '<div class="header">' +
+		var html = ((bookNameToDisplay) ? '<span id="selectedBookName" class="stepFgBg" style="font-size:18px"><b>' + bookNameToDisplay + '</b></span>' : '') +
+			'<div class="header">' +
             '<h4>' + headerMsg + '</h4>';
         if ((isChapter) && 
 			 ((userLang.toLowerCase().indexOf("en") == 0) || (this.hasEnglishBible)) &&
@@ -548,7 +549,6 @@ step.passageSelect = {
 					'</button>';
         html +=
             '</div>' +
-			((bookNameToDisplay) ? '<span id="selectedBookName" class="stepFgBg" style="font-size:18px"><b>' + bookNameToDisplay + '</b></span>' : '') +
 			'<div style="overflow-y:auto">' +
 			'<table>' +
 			'<colgroup>';


### PR DESCRIPTION
Per review of the deployed feature: the book name reads better as a title above "Please select a chapter/verse" than as a subtitle below it.


Claude-Session: https://claude.ai/code/session_019iMHw7cseNqeqHS3hs6oDE