### PR TITLE
Copy modal: scope the highlight to its panel

### DIFF
--- a/step-web/src/main/webapp/js/backbone/views/view_menu_copy.js
+++ b/step-web/src/main/webapp/js/backbone/views/view_menu_copy.js
@@ -33,6 +33,7 @@ step.copyDropdown = step.copyDropdown || {
         this.openView = view;
         if (step.lastPassageSelection) {
             this.selectionSnapshot = {
+                passageId: step.lastPassageSelection.passageId,
                 startVerse: step.lastPassageSelection.startVerse,
                 endVerse: step.lastPassageSelection.endVerse,
                 versions: (step.lastPassageSelection.versions || []).slice(0),
@@ -641,6 +642,7 @@ var PassageCopyMenuView = Backbone.View.extend({
     remove: function () {
         if (step.copyDropdown.views[this.panelId] === this) delete step.copyDropdown.views[this.panelId];
         if (step.copyDropdown.openPanelId === this.panelId) step.copyDropdown.release(this.panelId);
+        if (step.lastPassageSelection && step.lastPassageSelection.passageId === this.panelId) step.lastPassageSelection = null;
         if (this._statusTimer) { clearTimeout(this._statusTimer); this._statusTimer = null; }
         // Document- and window-level listeners outlive this.$el, so they have
         // to come off explicitly or a closed panel keeps dragging.
@@ -759,10 +761,10 @@ var PassageCopyMenuView = Backbone.View.extend({
         if (endIdx === -1 && startIdx > -1) endIdx = startIdx;
 
         if (startIdx === -1 || endIdx === -1) {
-            // Warn only about a fresh failed highlight; a stale one (e.g. made
-            // in a passage no longer displayed) silently falls back to the
-            // whole-display prefill.
-            result.unresolvable = (Date.now() - snap.timestamp < 60000);
+            // Warn only about a fresh failed highlight from this panel; a stale
+            // or foreign one silently falls back to the whole-display prefill.
+            result.unresolvable = (Date.now() - snap.timestamp < 60000) &&
+                (snap.passageId === undefined || snap.passageId === this.panelId);
             return result;
         }
 
@@ -1241,6 +1243,7 @@ var PassageCopyMenuView = Backbone.View.extend({
         this._statusTimer = setTimeout(function () {
             self._clearInlineSuccess();
             self._updateGridVisuals(); // re-enables the primary; the range is still armed
+            if (document.activeElement === document.body) self._focusInitial();
             self._statusTimer = null;
         }, 1500);
     },

--- a/step-web/src/main/webapp/js/step.util.js
+++ b/step-web/src/main/webapp/js/step.util.js
@@ -1883,7 +1883,8 @@ step.util = {
 				"initSelectionTracking": function () {
 					var debounceTimer;
 					step.lastPassageSelection = null;
-					document.addEventListener('selectionchange', function () {
+					document.addEventListener('selectionchange', function (e) {
+						if (e.target !== document) return; // text controls' own selectionchange bubbles here
 						clearTimeout(debounceTimer);
 						debounceTimer = setTimeout(function () {
 							var sel = window.getSelection();
@@ -1916,6 +1917,7 @@ step.util = {
 							addVersionIfNeeded(startInfo.version);
 							addVersionIfNeeded(endInfo.version);
 							step.lastPassageSelection = {
+								passageId: parseInt($(startEl).closest('.passageContainer').attr('passage-id')),
 								startVerse: startInfo.verse,
 								endVerse: endInfo.verse,
 								versions: allVersions,


### PR DESCRIPTION
A highlight made in one panel was snapshotted into another panel's copy menu, failed to resolve there and, being under 60 s old, left the Copy chip disabled behind the "couldn't match" warning instead of prefilling the whole display. The tracker also re-stamped a still-live highlight whenever a sync-update rewrote the search inputs, because a text control's selectionchange bubbles to the document listener.

- tracker records passageId and ignores non-document selectionchange
- a fresh unmatched highlight warns only when it came from this panel
- the post-copy timer refocuses the chip when focus fell to body
- closing a panel drops its highlight (panel ids are recycled)


Claude-Session: https://claude.ai/code/session_01EJcAFJ2nCqkMuyHYpo8qak